### PR TITLE
typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ skript/images/*.eps
 skript/images/*.pdf
 skript/images/*.[0-9]
 skript/images/*.[0-9][0-9]
+skript/checklist.pdf
+skript/skript.pdf
+skript/tacho/*.pdf
+skript/tacho/*.[0-9]
+skript/tacho/*.mpx

--- a/skript/binomialverteilung.tex
+++ b/skript/binomialverteilung.tex
@@ -26,7 +26,7 @@ Varianz&$\displaystyle np(1-p)$\\
 \hline
 Anwendungen&\begin{minipage}{3.7in}%
 \strut
-$\bullet$ Anzahl Eintreten eines Bernoulli-Experimentes
+$\bullet$ Anzahl Eintreten eines Bernoulliexperimentes
 \strut
 \end{minipage}\\
 \hline
@@ -75,7 +75,7 @@ ist.
 \end{definition}
 
 Die Wahrscheinlichkeitsverteilung und die Verteilungsfunktion der
-Binomialverteilung ist in Abbildung~\ref{binomialgraph} dargstellt.
+Binomialverteilung ist in Abbildung~\ref{binomialgraph} dargestellt.
 
 \subsubsection{Erwartungswert und Varianz}
 \index{Erwartungswert!der Binomialverteilung}

--- a/skript/chi2verteilung.tex
+++ b/skript/chi2verteilung.tex
@@ -3,7 +3,7 @@
 %
 % (c) 2015 Prof Dr Andreas Mueller, Hochschule Rapperswil
 %
-\subsection{\texorpdfstring{$\chi^2$}{Chi hoch 2}-Verteilung}\label{chi2verteilung}
+\subsection{\texorpdfstring{$\chi^2$}{Chi hoch 2}-Verteilung} \label{chi2verteilung}
 \index{chi@{$\chi^2$-Verteilung}}
 Der zentrale Grenzwertsatz garantiert, dass in vielen praktisch wichtigen
 F"allen ann"ahernd normalverteilte Zufallsvariablen vorliegen.
@@ -56,7 +56,7 @@ Um diesen Satz zu beweisen, ist es n"utzlich, mehr Information "uber die
 Dichtefunktionen zu sammeln.
 Zun"achst sind die Dichtefunktionen
 $\gamma_{\frac12,\frac{n}2}$ Elemente einer viel gr"osseren Familie von
-Dichtefunktionen, n"amlich den Gamma-Verteilungen
+Dichtefunktionen, n"amlich den Gamma-Verteilungen.
 
 \subsubsection{Die Gamma-Verteilungen}
 \index{gamma@{$\gamma$-Verteilung}}
@@ -125,7 +125,7 @@ x^{\mu+\nu-1}
 \end{align*}
 wobei f"ur die Umformung des Integrals die Substitution $t=x\tau$ verwendet
 wurde.
-Somit ist das Faltungsprodukt bis auf eine konstanten Faktor
+Somit ist das Faltungsprodukt bis auf einen konstanten Faktor
 wieder eine Gamma-Verteilung, da aber die Gamma-Verteilungen bereits
 normiert sind, muss der Faktor eins sein. Als Nebenprodukt erhalten
 wir also die Formel
@@ -155,7 +155,7 @@ Die Ableitung nach $x$ ergibt die Dichtefunktion:
 \[
 \varphi(x)=\frac1{\sqrt{\pi}}\Gamma({\textstyle\frac12})\gamma_{\frac12,\frac12}(x)
 \]
-Der Wert der Gamma-Funktion ist
+Der Wert der Gamma-Funktion
 \[
 \Gamma({\textstyle\frac12})
 =\int_0^\infty x^{-\frac12}e^{-x}\,dx
@@ -214,7 +214,7 @@ M_{\chi_1^2}(t)
 %&
 =\frac1{\sqrt{1-2t}}=(1-2t)^{-\frac12},
 \end{align*}
-wobei wir die Subsitutionen $-\alpha=t-\frac12$ und $\alpha x=\xi$
+wobei wir die Substitutionen $-\alpha=t-\frac12$ und $\alpha x=\xi$
 verwendet haben.
 Somit ist
 \[

--- a/skript/db-binomialverteilung.tex
+++ b/skript/db-binomialverteilung.tex
@@ -24,7 +24,7 @@ Varianz&$\displaystyle np(1-p)$\\
 \hline
 Anwendungen&\begin{minipage}{3.7in}%
 \strut
-$\bullet$ Anzahl Eintreten eines Bernoulli-Experimentes
+$\bullet$ Anzahl Eintreten eines Bernoulliexperimentes
 \strut
 \end{minipage}\\
 \hline
@@ -39,7 +39,7 @@ Binomialverteilung mit $p=0.4$ und $n=10$:
 \end{center}
 
 \subsection{Parameter sch"atzen}
-Wir ein Bernoulli-Experiment mit $m$ Wiederholungen $n$ mal wiederholt, erh"alt
+Wir ein Bernoulliexperiment mit $m$ Wiederholungen $n$ mal wiederholt, erh"alt
 man $n$ Werte $k_1,\dots,k_n$.
 Die Wahrscheinlichkeit $p$ kann daraus mit Hilfe des Mittelwertes erwartungstreu
 gesch"atzt werden:

--- a/skript/dgleichverteilung.tex
+++ b/skript/dgleichverteilung.tex
@@ -12,7 +12,7 @@
 \begin{center}
 \begin{tabular}{|l|l|}
 \hline
-Name&diskrete Gleichverteilung\\
+Name&Diskrete Gleichverteilung\\
 \hline
 Wahrscheinlichkeit&
 \begin{minipage}{3.7in}

--- a/skript/einleitung.tex
+++ b/skript/einleitung.tex
@@ -6,7 +6,7 @@
 \rhead{Einleitung}
 \chapter*{Einleitung}
 Neben den Verschw"orungstheoretikern jeder Couleur findet man
-in Youtube eine eigentliche Subkultur von Wissenschaftsverweigerern,
+auf YouTube eine eigentliche Subkultur von Wissenschaftsverweigerern,
 Evolutionsgegnern, Tesla-Anbetern (alle heutigen Erfindungen sind im
 Prinzip schon von Nikola Tesla gemacht worden), Chemtrailern, 
 Ufo-J"agern,
@@ -147,7 +147,7 @@ Die falsche Aussage falsifiziert ein Modell.
 
 Zum Beispiel kann man aus dem Kugelmodell ableiten, dass der Weg
 auf einem Breitenkreis auf $80^\circ$ n"ordlicher Breite
-sehr viel k"urzer sein muss ein Weg entlang des "Aquators.
+sehr viel k"urzer sein muss als ein Weg entlang des "Aquators.
 Diese Aussage trifft aber auch f"ur das Scheibenmodell zu, sie
 ist also nicht geeignet, eines der Modelle zu falsifizieren.
 Sie w"are h"ochstens geeignet, das Zylinder-Modell der Erde

--- a/skript/einleitung.tex
+++ b/skript/einleitung.tex
@@ -84,9 +84,9 @@ zur"uckgeht, und die Existenz eines ``maximal grossartigen Wesens''
 nachweisen soll. 
 Selbst wenn das Argument korrekt w"are\footnote{Es behauptet im wesentlichen,
 dass ein maximal grossartiges Wesen existieren m"usse, weil nicht Existenz
-der maximalen Grossartigkeit abbruch tun w"urde.
-Aber ein offenes Interval enth"alt alle Zahlen, die nicht ganz so gross
-sind wie das rechte Ende des Intervals, also alle nicht ganz maximalen
+der maximalen Grossartigkeit Abbruch tun w"urde.
+Aber ein offenes Intervall enth"alt alle Zahlen, die nicht ganz so gross
+sind wie das rechte Ende des Intervalls, also alle nicht ganz maximalen
 Zahlen, nur eben die maximale Zahl nicht.
 Das Argument ist also im wesentlichen ein Wortspiel um den Begriff eines
 ``maximal grossartigen'' Wesens.}, w"urde es niemals die Existenz eines
@@ -135,7 +135,7 @@ Aussagen ableiten, die mit einem Experiment "uberpr"ufbar sind.
 Die Aussagen m"ussen f"ur die in Frage kommenden Hypothesen gegens"atzlich
 sein.
 Es reicht also nicht, eine Aussage zu haben und experimentell zu
-verfizieren, die f"ur das Kugelmodell der Erde zutrifft,
+verifizieren, die f"ur das Kugelmodell der Erde zutrifft,
 die Aussage darf gleichzeitig f"ur das Scheibenmodell der Erde
 nicht zutreffen.
 Eine solche Aussage l"asst uns entscheiden, welches der Modelle
@@ -195,7 +195,7 @@ Achse dreht.
 Lichtstrahlen breiten sich entlang von Geraden aus.
 \end{enumerate}
 Das Experiment hat die erste Hypothese falsifiziert, aber wir wissen
-damit noch nicht, ob die Kugelgestalt wiederlegt wurde, oder die
+damit noch nicht, ob die Kugelgestalt widerlegt wurde, oder die
 Gradlinigkeit der Lichtausbreitung.
 
 Es stellte sich heraus, wie Albert Russel Wallace sp"ater nachgewiesen,

--- a/skript/erwartung.tex
+++ b/skript/erwartung.tex
@@ -4,8 +4,7 @@
 % (c) 2006-2015 Prof. Dr. Andreas Mueller, Hochschule Rapperswil
 %
 \rhead{Zufallsvariable, Erwartung und Varianz}
-\chapter{Zufallsvariable und Erwartungswert
-\label{chapter-erwartungswert-und-varianz}}
+\chapter{Zufallsvariable und Erwartungswert} \label{chapter-erwartungswert-und-varianz}
 
 Bis jetzt hat uns nur das Eintreten von Ereignissen interessiert, und
 der entwickelte Formalismus war auch nur darauf ausgelegt.
@@ -19,7 +18,7 @@ eines Ereignisses w"ahlt, also wieder eine Zahl.
 In diesem Fall treten nat"urlich nur ganzzahlige Resultate auf.
 
 Der Ereignis-Formalismus kann uns bestenfalls die Wahrscheinlichkeit
-daf"ur liefern, dass ein Messwert in ein bestimmtes Interval f"allt.
+daf"ur liefern, dass ein Messwert in ein bestimmtes Intervall f"allt.
 Er kann uns aber nicht helfen die folgenden Fragen zu beantworten:
 \begin{enumerate}
 \item Mit welchem ungef"ahren Wert kann man bei der Durchf"uhrung der
@@ -33,7 +32,7 @@ Um diese Fragen beantworten zu k"onnen, m"ussen wir unserem Modell
 der Ereignisse und Wahrscheinlichkeiten zun"achst 
 ein Modell f"ur den Messprozess anf"ugen.
 Das Konzept der Wahrscheinlichkeit m"ussen wir sodann feiner ausgestalten,
-um einen ``Erwartunsgwert'' daraus ableiten zu k"onnen.
+um einen ``Erwartungswert'' daraus ableiten zu k"onnen.
 Das gleiche Konzept wird uns auch dazu dienen, eine Masszahl f"ur
 die Streuung zu entwickeln, und daraus bereits eine Anzahl interessanter
 Anwendungen zu konstruieren.
@@ -472,7 +471,7 @@ und dann noch $n-k$ Zahlen aus $\Omega\setminus A$.
 Ersteres ist
 auf $\binom{|A|}{k}$ Arten m"oglich, letzteres auf $\binom{N-|A|}{n-k}$
 Arten.
-Insgesammt gibt es also 
+Insgesamt gibt es also 
 \[
 \binom{M}{k}\binom{N-M}{n-k}
 \]
@@ -553,7 +552,7 @@ Voraussetzungen gemacht werden m"ussen, um $E(XY)$ berechnen zu k"onnen.
 \includegraphics[width=0.3\hsize]{images/erwartung-3}
 \includegraphics[width=0.3\hsize]{images/erwartung-2}
 \end{center}
-\caption{Ereignisse $A_i$ zur Berechung von $E(X)$, $B_j$ zur Berechnung
+\caption{Ereignisse $A_i$ zur Berechnung von $E(X)$, $B_j$ zur Berechnung
 von $E(Y)$ und $A_i\cap B_j$ zur Berechnung von $E(XY)$.
 \label{productexpectation}}
 \end{figure}
@@ -648,7 +647,7 @@ M"oglichkeiten zur Berechnung von $E(X)$ bietet, verfolgen wir sie
 hier nicht weiter, werden aber im n"achsten Kapitel eine verwandte
 Technik kennen lernen, welche nur gew"ohnliche Integrale verwendet.
 
-\section{Varianz\label{section-varianz}}
+\section{Varianz}\label{section-varianz}
 \index{Varianz}
 Die Qualit"atskontrolle bei der Herstellung von Widerst"anden versucht
 ein Mass daf"ur zu entwickeln, wie genau die produzierten Widerst"ande
@@ -734,9 +733,15 @@ reelle Zahl $\mu$, f"ur die $E((X-\mu)^2)$ minimal wird.
 \begin{proof}[Beweis]
 Aus den Rechenregeln finden wir
 \begin{align*}
-E((X-\mu)^2)&=&E(X^2-2\mu X+\mu^2)\\
-&=E(X^2)-2\mu E(X) +\mu^2E(1)\\
-&=E(X^2)-2\mu E(X) +\mu^2
+E((X-\mu)^2)
+&=
+E(X^2-2\mu X+\mu^2)
+\\
+&=
+E(X^2)-2\mu E(X) +\mu^2E(1)
+\\
+&=
+E(X^2)-2\mu E(X) +\mu^2
 \end{align*}
 Dies ist eine quadratische Funktion, die ihren Scheitelpunkt bei $\mu$ hat.
 Man kann dies auch durch Nullsetzen der Ableitung nach $\mu$ finden:
@@ -988,7 +993,7 @@ Meistens wird die Abweichung klein sein.
 Uns interessiert jetzt aber,
 wie wahrscheinlich es ist, dass sie gross ist.
 Sei $\varepsilon>0$ ein Schwellwert f"ur die Abweichung, wir m"ochten
-also wissen, wie h"aufig die Abweichung $\varepsilon$ "uberschreitete:
+also wissen, wie h"aufig die Abweichung $\varepsilon$ "uberschritt:
 \[
 |X-\mu|>\varepsilon.
 \]
@@ -1002,7 +1007,7 @@ zwischen Varianz und und dieser Wahrscheinlichkeit geben: je gr"osser
 die Varianz, desto gr"osser die Wahrscheinlichkeit einer grossen
 Abweichung.
 
-\subsection{Ungleichung von Tschebyscheff}\label{ungleichung-von-tschebyscheff}
+\subsection{Ungleichung von Tschebyscheff} \label{ungleichung-von-tschebyscheff}
 \index{Tschebyscheff!Ungleichung von}
 Selbst wenn man gar nichts "uber die Zufallsvariable weiss, ausser
 dass sie eine Varianz besitzt, kann man eine Aussage "uber die 
@@ -1014,7 +1019,7 @@ mehr "uber das konkrete Experiment wissen.
 \begin{figure}
 \centering
 \includegraphics{images/erwartung-5.pdf}
-\caption{Zur Herleitung der Tschebyscheff-Ungleichung: Eregnisse, in denen 
+\caption{Zur Herleitung der Tschebyscheff-Ungleichung: Ereignisse, in denen 
 die Zufallsvariable um mehr als $\varepsilon$ vom Erwartungswert $\mu$
 abweicht.
 \label{tschebyscheff-herleitung}}
@@ -1022,7 +1027,7 @@ abweicht.
 \begin{figure}
 \centering
 \includegraphics{images/erwartung-6.pdf}
-\caption{Herleitung der Tschebyscheff-Ungleichung, charakterstische Funktion
+\caption{Herleitung der Tschebyscheff-Ungleichung, charakteristische Funktion
 des Ereignisses $|X-\mu|>\varepsilon$ ist blau eingezeichnet.
 \label{tschebyscheff2}}
 \end{figure}
@@ -1092,7 +1097,7 @@ P(|X-\mu|>2\sqrt{\operatorname{var}(X)})
 Diese Ungleichung gilt f"ur jede Zufallsvariable $X$.
 Es gibt aber Zufallsvariablen, f"ur die 
 \[
-P(|X-\mu|>2\sqrt{\operatorname{var}(X)})\le 0.05,
+P(|X-\mu|>2\sqrt{\operatorname{var}(X)})\le 0.05.
 \]
 Wir werden mit der Normalverteilung solche Zufallsvariablen kennenlernen.
 Auf das Beispiel angewendet bedeutet dies, dass die Tschebyscheff-Ungleichung
@@ -1100,8 +1105,7 @@ m"oglicherweise viel zu oft behauptet, dass die Produktionsqualit"at ungen"ugend
 ist, weil die Widerstandswerte vermutlich in guter N"aherung normalverteilt
 sein werden.
 
-\subsection{Wie gut approximiert der Mittelwert den Erwartungswert?}
-\label{approximation-mittelwert}
+\subsection{Wie gut approximiert der Mittelwert den Erwartungswert?} \label{approximation-mittelwert}
 Wir betrachten eine Folge von unabh"angigen Zufallsvariablen $X_1, X_2,\dots$, die
 alle den gleichen Erwartungswert $E(X_i)=\mu$ und die gleiche Varianz
 $\operatorname{var}(X_i)=\sigma^2$ haben.
@@ -1230,7 +1234,7 @@ Um den Fehler zu halbieren, muss die Anzahl der Versuche
 vervierfacht werden.
 \label{fehlerabnahme}}
 \end{figure}
-Der verbleibende Fehler der relativen H"aufigkeit ist propertional zu
+Der verbleibende Fehler der relativen H"aufigkeit ist proportional zu
 $\frac1{\sqrt{n}}$, wenn $n$ die Anzahl der Versuche ist.
 Die Abh"angigkeit des zu erwartenden Fehlers der relativen H"aufigkeit mit
 der Anzahl der Versuche ist in Abbildung~\ref{fehlerabnahme} dargestellt.
@@ -1246,7 +1250,7 @@ der Anzahl der Versuche ist in Abbildung~\ref{fehlerabnahme} dargestellt.
 \includegraphics{images/regression-1.pdf}
 \end{center}
 \caption{Anpassung einer Geraden an gemessene
-Strom-/Spannungs-Werte\label{ohm-regression}}
+Strom-/Spannungswerte\label{ohm-regression}}
 \end{figure}
 Der Satz \ref{erwartungswert-charakterisierung} hat gezeigt, dass der
 Erwartungswert jener Wert ist, der die Varianz minimiert.
@@ -1259,7 +1263,7 @@ F"uhrt man eine Messung von beiden
 Gr"ossen durch, erh"alt man zwei Zufallsvariablen $U(\omega)$ und $I(\omega)$,
 und die Proportionalit"at wird wegen der Messfehler meistens nicht mehr
 erf"ullt sein.
-Wie gross ist der Widerstansdwert $R$? Es w"are zwar denkbar,
+Wie gross ist der Widerstandswert $R$? Es w"are zwar denkbar,
 f"ur jede Messung den Widerstandswert zu errechnen, und dann das Mittel
 zu bilden.
 Noch besser ist aber, den Widerstandswert $R$ so zu bestimmen,
@@ -1274,13 +1278,18 @@ Etwas allgemeiner finden wir folgenden Satz "uber die sogenannte
 Regressionsgerade:
 \begin{satz}
 \label{rekursion}
-Seien $X$ und $Y$ zwei reelle Zufallsvariable.
+Seien $X$ und $Y$ zwei reelle Zufallsvariablen.
 Die Gerade mit der
 Gleichung $y=ax+b$ minimiert die Varianz
 $\operatorname{var}(aX+b-Y)$ genau dann, wenn 
 \begin{align*}
-a&=\frac{E(XY)-E(X)E(Y)}{(E(X^2)-E(X)^2)}=\frac{\operatorname{cov}(X,Y)}{\operatorname{var}(X)},\\
-b&=E(Y)-E(X)a.
+a
+&=
+\frac{E(XY)-E(X)E(Y)}{(E(X^2)-E(X)^2)}=\frac{\operatorname{cov}(X,Y)}{\operatorname{var}(X)},
+\\
+b
+&=
+E(Y)-E(X)a.
 \end{align*}
 \end{satz}
 \begin{proof}[Beweis]
@@ -1318,7 +1327,7 @@ womit alles bewiesen ist.
 Die Gleichung f"ur $b$ hat eine unmittelbare Konsequenz: die Regressionsgerade
 geht immer durch den Punkt $(E(X), E(Y))$.
 In der Tat, damit der Punkt
-$(E(X), E(Y))$ auf der Geraden liegt, muss die Bedinung $E(Y)=aE(X)+b$
+$(E(X), E(Y))$ auf der Geraden liegt, muss die Bedingung $E(Y)=aE(X)+b$
 erf"ullt sein.
 Schafft man $aE(X)$ auf die linke Seite, wird daraus
 
@@ -1437,7 +1446,7 @@ verf"ugbar, muss
 ein l"angeres Verz"ogerungselement durch Verk"urzung auf die passende
 Verz"ogerungszeit eingestellt werden.
 Dazu muss jedoch der Zusammenhang
-zwischen Verz"ogerungszeit und l"ange des Elementes bekannt sein.
+zwischen Verz"ogerungszeit und L"ange des Elementes bekannt sein.
 Der Hersteller macht die Angaben in Tabelle \ref{delaylengths}.
 
 \subsubsection{Berechnung von Hand}
@@ -1501,8 +1510,7 @@ Die Software R
 ist ein leistungsf"ahiges freies Softwarepaket f"ur statistische
 Berechnungen.
 Mit folgenden Befehlen kann das obige Regressionsproblem
-mit R gel"ost, und die Graphik
-Graphik \ref{verzoegerungszeit} dargestellt
+mit R gel"ost, und die Graphik \ref{verzoegerungszeit} dargestellt
 werden:
 
 {\footnotesize
@@ -1535,4 +1543,4 @@ F-statistic: 646.9 on 1 and 2 DF,  p-value: 0.001542
 > abline(laenge.lm)
 \end{verbatim}
 }
-R kann von \url{http://www.r-project.org} heruntergeladen werden.
+R kann von \url{https://www.r-project.org} heruntergeladen werden.

--- a/skript/exponentialverteilung.tex
+++ b/skript/exponentialverteilung.tex
@@ -56,7 +56,7 @@ und $t_0+t$ zerf"allt, wenn er bis zur Zeit $t_0$ nicht zerfallen ist.
 Auch Bauteile ohne Erm"udungserscheinungen verhalten sich so.
 
 \subsubsection{Verteilungsfunktion und Dichtefunktion}
-Etwas formaler sei $X$ eine Zufallsvariable, die die Zeit angibt, zu der
+Etwas formaler sei $X$ eine Zufallsvariable, welche die Zeit angibt, zu der
 ein Atomkern zerf"allt.
 Die ``Ged"achtnislosigkeit'' bedeutet, dass die
 bedingte Wahrscheinlichkeit f"ur einen Zerfall vor $t_0+t$ unter der
@@ -142,7 +142,7 @@ auch die Ableitung ist richtig:
 \index{Varianz!der Exponentialverteilung}
 \index{Exponentialverteilung!Varianz}
 \begin{satz}Eine exponentialverteilte Zufallsvariable $X$ mit Parameter
-$a$ hat folgenden Erwartungswert und folgene Varianz:
+$a$ hat folgenden Erwartungswert und folgende Varianz:
 \begin{align*}
 E(X)&=\frac1a\\
 \operatorname{var}(X)&=\frac1{a^2}
@@ -194,7 +194,7 @@ ist genau gleich gross.
 \includegraphics{images/exp-1.pdf}
 \end{center}
 \caption{Wahrscheinlichkeit f"ur eine grosse Abweichung bei einer
-Exponentialverteilten Zufallsvariable, oben die durch den Satz von Tschebyscheff
+exponentialverteilten Zufallsvariable, oben die durch den Satz von Tschebyscheff
 gegebene Schranke (gr"un), unten die exakte Rechnung mit
 Hilfe der Exponentialvereteilung (rot)\label{abweichung-exponential}}
 \end{figure}
@@ -203,7 +203,7 @@ Hilfe der Exponentialvereteilung (rot)\label{abweichung-exponential}}
 Wir k"onnen nun auch die Wahrscheinlichkeit einer grossen Abweichung
 berechnen:
 \begin{satz} F"ur eine exponentialverteilte Zufallsvariable mit
-Erwartungswert $\frac1a$ ist die Wahscheinlichkeit einer Abweichung
+Erwartungswert $\frac1a$ ist die Wahrscheinlichkeit einer Abweichung
 $\varepsilon$ vom Erwartungswert
 \[
 P(|X-{\textstyle\frac1a}|>\varepsilon)=

--- a/skript/filter.tex
+++ b/skript/filter.tex
@@ -8,7 +8,7 @@
 
 In den vergangenen Kapiteln wurden unter den Voraussetzungen einer
 bekannten Verteilung einer einzigen Zufallsvariablen Methoden entwickelt,
-die Parameter der Verteilung zu sch"atzen, und die deraus gewonnen
+die Parameter der Verteilung zu sch"atzen, und die daraus gewonnenen
 Hypothesen gegebenenfalls zu testen.
 "Uberlicherweise musste man dazu
 mehrere Beobachtungen der gleichen Zufallsvariablen vornehmen.
@@ -173,7 +173,7 @@ zu verwenden.
 Es gibt also eine Matrix $H_k$, welche die beobachteten
 Gr"ossen $z_k=H_kx_k$ bestimmt.
 
-Die Zeitwentwicklung des Systems muss aus einem Zustand $x_k$ den n"achsten
+Die Zeitentwicklung des Systems muss aus einem Zustand $x_k$ den n"achsten
 Zustand $x_{k+1}$ berechnen.
 Bei einem
 einfachen System mit der Bewegungsgleichung
@@ -205,7 +205,7 @@ gibt die Unzul"anglichkeiten des durch $\varphi_k$ beschriebenen Modells
 wieder.
 \label{filter-systementwicklung}}
 \end{figure}
-In der Realtit"at bewegt sich das System kaum genau nach diesen Gleichungen.
+In der Realit"at bewegt sich das System kaum genau nach diesen Gleichungen.
 Vielmehr wird es von "ausseren St"orungen beeinflusst, die sich einer
 exakten Vorhersage entziehen, wir tragen dem Rechnung mit Hilfe eines
 zus"atzlichen Zufallsvektors $u_k$ in den Bewegungsgleichungen
@@ -575,7 +575,7 @@ P_k=(I-K_kH_k)P_{k|k-1}.
 \caption{Berechnung der Kalman-Matrix\label{k-berechnung}}
 \end{figure}
 Abbildung \ref{datenfluss} zeigt den Datenfluss f"ur den Kalman Filter.
-Im oberen Teil des Diagrams ist das `unbeobachtete' System mit seiner
+Im oberen Teil des Diagramms ist das `unbeobachtete' System mit seiner
 Zeitentwicklung und den Systemfehlern $u_k$ dargestellt.
 Unterhalb der
 punktierten Linie folgt die Messung, die Matrix $H_k$ reduziert den Zustand

--- a/skript/google.tex
+++ b/skript/google.tex
@@ -20,7 +20,7 @@ Wie misst man, wie gut eine Seite passt.
 \subsubsection{Das Problem}
 Bei der Suche in einer kleinen Dokumentmengen schr"ankt die Angabe von
 gen"ugend vielen Suchkriterien die Resultatmenge meistens so stark
-ein, dass man damit ewas Sinnvolles anfangen kann.
+ein, dass man damit etwas Sinnvolles anfangen kann.
 Die Dokumentmenge
 des Internet ist jedoch so gross, dass die Suche nach einigermassen
 gebr"auchlichen W"ortern notwendigerweise zehntausend oder hunderttausende
@@ -117,7 +117,7 @@ P(S'_j|S_i)=\begin{cases}
 \]
 Die Ereignisse $S_i$ sind disjunkt, kein Surfer darf auf mehr als einer
 Seite gleichzeitig sein.
-Ausserdem "uberdecken sie ganz $\Omega$, jeder Surfer ist auf irgend einer
+Ausserdem "uberdecken sie ganz $\Omega$, jeder Surfer ist auf irgendeiner
 Seite.
 Daher gilt nach dem Satz "uber die totale Wahrscheinlichkeit
 \[

--- a/skript/kombinatorik.tex
+++ b/skript/kombinatorik.tex
@@ -55,7 +55,7 @@ Stehen an den Positionen $i\in\{1,\dots,k\}$ jeweils die $n_i$
 Wahlm"oglichkeiten
 zur Verf"ugung, ist die Gesamtzahl der M"oglichkeiten:
 \[
-n_1\cdot n_2\cdots n_k=\prod_{i=1}^kn_i.
+n_1\cdot n_2\dotsm n_k=\prod_{i=1}^kn_i.
 \]
 Die Produktregel ist immer dann anwendbar wenn man das Entstehen
 aller M"oglichkeiten aus den Wahlm"oglichkeiten an jeder Position
@@ -151,7 +151,7 @@ So geht es weiter bis zum letzten Objekt, f"ur welches
 genau ein Platz "ubrig bleibt.
 Es folgt
 \[
-P_n=n(n-1)(n-2)\dots 2\cdot 1=n!
+P_n=n(n-1)(n-2)\dotsm 2\cdot 1=n!
 \]
 
 Man kann f"ur $P_n$ auch eine Rekursionsformel finden.
@@ -293,18 +293,18 @@ es Permutationen von $k$ Objekten gibt.
 Man muss also noch durch
 $P_k=k!$ teilen:
 \[
-C^n_k=\frac{n(n-1)(n-2)\cdots(n-k+1)}{k!}.
+C^n_k=\frac{n(n-1)(n-2)\dotsm(n-k+1)}{k!}.
 \]
 Durch Erweitern mit $(n-k)!$ bekommt man eine etwas
 kompaktere Formel:
 \[
-C^n_k=\frac{n(n-1)(n-2)\cdots(n-k+1)\cdot(n-k)(n-k-1)\cdots2\cdot 1}{k!(n-k)!}
+C^n_k=\frac{n(n-1)(n-2)\dotsm(n-k+1)\cdot(n-k)(n-k-1)\dotsm2\cdot 1}{k!(n-k)!}
 =\frac{n!}{k!(n-k)!}
 \]
 
 Auch f"ur diese Gr"osse kann man eine Rekursionsformel finden.
 Die Zahl der Auswahlen von $k$ Elementen aus $n$ gibt es
-offenbar $C^{n-1}{k}$ Auswahlen, welche das erste Element nicht
+offenbar $C^{n-1}_{k}$ Auswahlen, welche das erste Element nicht
 enthalten, und $C^{n-1}_{k-1}$ Auswahlen, die dadurch entstehen,
 dass man zun"achst das erste Element in die Auswahl nimmt, und dann
 aus den verbleibenden Elementen deren $k-1$ hinzuf"ugt.
@@ -577,8 +577,8 @@ p_n(z)=C^n_0+C^n_1z +C^n_2z^2+\dots+C^n_{n-1}z^{n-1}+C^n_nz^n.
 \]
 Interpretieren wir zun"achst $p_1(z)$.
 Die Koeffizienten dieses
-Polynoms geben an, auf wieviele Arten man kein Element aus einer
-einelementigen Menge ausw"ahlen kann, bzw.~auf wieviele Arten man 
+Polynoms geben an, auf wie viele Arten man kein Element aus einer
+einelementigen Menge ausw"ahlen kann, bzw.~auf wie viele Arten man 
 ein Element ausw"ahlen kann.
 Beides ist genau auf eine Art m"oglich,
 also
@@ -589,11 +589,11 @@ Betrachten wir jetzt $p_1(z)^n$.
 Beim Ausmultiplizieren des
 Produktes 
 \[
-p_1(z)^n= (1+z)(1+z)\cdots(1+z),
+p_1(z)^n= (1+z)(1+z)\dotsm(1+z),
 \]
 stellt sich die Frage, wie viele Summanden $z^k$ f"ur jedes
 $k$ auftreten werden.
-Damit $z^k$ ensteht, muss in $k$ Faktoren das $z$ gew"ahlt werden,
+Damit $z^k$ entsteht, muss in $k$ Faktoren das $z$ gew"ahlt werden,
 und in den anderen $n-k$ Faktoren die $1$.
 Dies ist auf $C^n_k$
 Arten m"oglich, wir haben also gezeigt, dass
@@ -660,7 +660,7 @@ Die erzeugende Funktion der konstanten Folge $1,1,1,\dots$ ist
 
 \begin{beispiele}
 \item 
-Auf wieviele Arten kann man 90 Rappen mit den verf"ugbaren M"unzen
+Auf wie viele Arten kann man 90 Rappen mit den verf"ugbaren M"unzen
 herausgeben?
 
 Die verf"ugbaren M"unzen sind 5er, 10er, 20er und 50er.
@@ -673,7 +673,7 @@ Die Zahl $a_n$ der M"oglichkeiten, mit der der Betrag
 $n$ herausgegeben werden kann, ist also
 \[
 a_n = \begin{cases}
-1&\qquad n\equiv 0\mod 5\\
+1&\qquad n\equiv 0\imod{5}\\
 0&\qquad \text{sonst}
 \end{cases}
 \]
@@ -711,7 +711,7 @@ C_{50}(x)&=1+x^{50}+x^{100}+\dots
 \end{align*}
 hinzu.
 Die erzeugende Funktion, mit der wir die M"oglichkeiten z"ahlen
-k"onnen, auf wieviele Arten man den Betrag aus allen M"unzen bilden kann,
+k"onnen, auf wie viele Arten man den Betrag aus allen M"unzen bilden kann,
 ist dann
 \begin{align*}
 C_5(x) C_{10}(x) C_{20}(x) C_{50}(x)
@@ -774,7 +774,7 @@ c =
 
  13 12 12 11 11 10  8  7  6  5  4  3  2  2  1  1
 \end{verbatim}
-Um jetzt herauszufinden, auf wieviele Arten man 11 Franken
+Um jetzt herauszufinden, auf wie viele Arten man 11 Franken
 kombinieren kann, muss man den Koeffizienten von $z^{11}$ in diesem
 Polynom finden, also den zw"olften Koeffizienten vom Ende des
 Vektors, zum Beispiel so:
@@ -826,7 +826,7 @@ derart, dass
 =
 (1-x^5-x^{10}+x^{15}) \sum_{k=0}^\infty c_kx^k=1
 \]
-Durch ausmultiplizieren findet man aus der rechten Seite
+Durch Ausmultiplizieren findet man aus der rechten Seite
 
 {\allowdisplaybreaks
 \begin{align*}

--- a/skript/normalverteilung.tex
+++ b/skript/normalverteilung.tex
@@ -50,7 +50,7 @@ Bedeutung.
 In sehr vielen Anwendungssituationen darf man davon ausgehen,
 dass die beobachteten Zufallsgr"ossen normalverteilt sind.
 Die Begr"undung
-f"ur diesen "uberraschenden Sachverhalt liefert der zentrale Grenzwert-Satz,
+f"ur diesen "uberraschenden Sachverhalt liefert der Zentrale Grenzwertsatz,
 welcher im wesentlich besagt, dass eine Zufallsvariable, die als Summe vieler
 kleiner, unabh"angiger Zufallseinfl"usse betrachtet werden kann, immer
 angen"ahert normalverteilt ist.
@@ -85,8 +85,8 @@ F(1)&=0.8413,&F(-1)&=1-F(1)=0.1587&&\Rightarrow&P(-1<X\le 1)&=68.28\%\\
 F(2)&=0.9772,&F(-2)&=1-F(2)=0.0228&&\Rightarrow&P(-2<X\le 2)&=95.4\%\\
 F(3)&=0.9987,&F(-3)&=1-F(3)=0.0013&&\Rightarrow&P(-3<X\le 3)&=99.7\%
 \end{align*}
-Zwei Drittel aller Messwerte fallen also in das Interval $[-1,1]$, und 95\%
-aller Messwerte in das Interval $[-2,2]$.
+Zwei Drittel aller Messwerte fallen also in das Intervall $[-1,1]$, und 95\%
+aller Messwerte in das Intervall $[-2,2]$.
 
 Man kann die Verteilungsfunktion der Standardnormalverteilung auch wie folgt
 numerisch zu berechnen versuchen:
@@ -138,7 +138,7 @@ F\biggl(\frac{a-\mu}{\sigma}\biggr).
 Die Werte von $F$ k"onnen entweder der Tabelle~\ref{tabelle-Fnormalverteilung}
 entnommen oder mit der Formel (\ref{Fnormal-erf}) berechnet werden.
 Die Werte in (\ref{normal-werte}) bedeuten dann, dass gut zwei Drittel aller
-Messwerte in das Interval $[\mu-\sigma, \mu+\sigma]$ fallen, und dass 
+Messwerte in das Intervall $[\mu-\sigma, \mu+\sigma]$ fallen, und dass 
 95\% der Messwerte sich in $[\mu-2\sigma,\mu+2\sigma]$ befinden.
 
 Der Vollst"andigkeit halber rechnen wir nach, ob die durch $\varphi$
@@ -434,7 +434,7 @@ Exponentialverteilung zeigt sich, dass die zus"atzliche Information
 "uber die Verteilung die Wahrscheinlichkeit f"ur eine grosse
 Abweichung deutlich besser absch"atzen l"asst.
 
-\subsubsection{Der zentrale Grenzwertsatz}
+\subsubsection{Der Zentrale Grenzwertsatz}
 \label{zentraler-grenzwertsatz}
 \index{Zentraler Grenzwertsatz}
 \index{Grenzwertsatz, zentraler}
@@ -504,7 +504,7 @@ Die Abbildung \ref{zgws} illustriert
 dies: dort wird die Wahrscheinlichkeitsdichte der standardisierten
 Summe von bis zu vier im
 Intervall $[-\sqrt{3},\sqrt{3}]$ gleichverteilte Zufallsvariablen dargestellt,
-und mit der Standardnormallverteilung verglichen.
+und mit der Standardnormalverteilung verglichen.
 
 Wir betrachten als technisches Hilfsmittel f"ur die Berechnung
 die folgende Funktion:
@@ -544,7 +544,7 @@ Der Plan ist daher der folgende:
 \item Bestimme einen N"aherungsausdruck f"ur $M_{X_i}(t)$.
 \item Bestimme einen N"aherungsausdruck f"ur $M_{S_n}(t)$.
 \item Berechne den Grenzwert von $M_{S_n}(t)$ f"ur $n\to\infty$.
-\item Finde eine Verteilung, die die gleiche Laplacetransformation
+\item Finde eine Verteilung, welche die gleiche Laplacetransformation
 hat.
 \end{enumerate}
 
@@ -563,11 +563,11 @@ $R_i(t)\to 0$ wenn $t\to 0$.
 Aus den beiden Rechenregeln f"ur die momenterzeugende Funktion folgt
 jetzt zun"achst f"ur die Summe der Zufallsvariablen
 \[
-M_{X_1+\dots+X_n}(t)=M_{X_1}(t)\dots M_{X_n}(t),
+M_{X_1+\dots+X_n}(t)=M_{X_1}(t)\dotsm M_{X_n}(t),
 \]
 und anschliessen f"ur das Produkt mit $\frac1{\sqrt{n}}$
 \[
-M_{S_n}(t)=M_{X_1}(t/\sqrt{n})\dots M_{X_n}(t/\sqrt{n}).
+M_{S_n}(t)=M_{X_1}(t/\sqrt{n})\dotsm M_{X_n}(t/\sqrt{n}).
 \]
 Durch Einsetzen der N"aherung aus dem ersten Schritt ergibt sich
 \[
@@ -616,7 +616,7 @@ momenterzeugende Funktion hat.
 Da die momenterzeugende Funktion
 nichts anderes als eine Laplacetransformation ist, k"onnen wir
 den Eindeutigkeitssatz f"ur die Laplacetransformation anwenden,
-welcher besagt, dass zwei Funktionen, die die gleiche zweiseitige
+welcher besagt, dass zwei Funktionen, welche die gleiche zweiseitige
 Laplacetransformierte haben, fast "uberall gleich sein.
 
 Wir rechnen nach, dass $e^{\frac{t^2}2}$ die momenterzeugende Funktion
@@ -654,18 +654,18 @@ M(t)
 \end{align*}
 Mit anderen Worten, die momenterzeugende Funktion der Normalverteilung
 stimmt "uberein mit der momenterzeugenden Funktion der Grenzverteilung.
-Schreiben $\varphi_n$ f"ur die Dichtefunktion f"ur $S_n$ und $F_n$
-f"ur die Verteilungsfunktion, dann gilt
-nach allgemeinen S"atzen "uber die Laplacetransformation gilt daher
+Schreiben wir $\varphi_n$ f"ur die Dichtefunktion f"ur $S_n$ und $F_n$
+f"ur die Verteilungsfunktion, dann gilt daher
+nach allgemeinen S"atzen "uber die Laplacetransformation
 \[
 \lim_{n\to\infty}\varphi_n(x)=\frac1{\sqrt{2\pi}}e^{-\frac{x^2}2}
 \quad\text{fast "uberall}
 \]
 und f"ur die Verteilungsfunktion
 \[
-\lim_{n\to\infty}F_n(x)=\frac1{\sqrt{2\pi}}\int_{-\infty}^xe^{-\frac{t^2}2}\,dt
+\lim_{n\to\infty}F_n(x)=\frac1{\sqrt{2\pi}}\int_{-\infty}^xe^{-\frac{t^2}2}\,dt.
 \]
-Insgesamt haben wir damit den folgenden Satz bewiesen
+Insgesamt haben wir damit den folgenden Satz bewiesen:
 \begin{satz}[Zentraler Grenzwertsatz]
 \label{satz-zentraler-grenzwertsatz}
 Sind $(X_i)_{1\le i}$ unabh"angige Zufallsvariablen mit

--- a/skript/poissonverteilung.tex
+++ b/skript/poissonverteilung.tex
@@ -216,7 +216,7 @@ W"urfel geworfen, und in einem $6\times 6$-Feld das Feld mit der
 erw"urfelten Zeilen- und Spalten-Nummer angekreuzt.
 Dabei muss man darauf
 achten, immer den gleichen W"urfel f"ur die Zeilen-Nummern zu verwenden.
-Dann wird ausgez"ahlt, wieviele Felder $k=0$, $k=1$, $k=2$,\dots\ Kreuze
+Dann wird ausgez"ahlt, wie viele Felder $k=0$, $k=1$, $k=2$,\dots\ Kreuze
 enthalten.
 
 Nat"urlich ist dies ein Bernoulli-Experiment.

--- a/skript/potenzverteilung.tex
+++ b/skript/potenzverteilung.tex
@@ -23,7 +23,7 @@ aber sehr selten, 5m grosse Menschen gibt es nicht.
 Andererseits gibt es auch Gr"ossen, die einen weiten Bereich von m"oglichen
 Werten annehmen.
 Mondkrater k"onnen mehrere Kilometer gross sein, oder auch
-nur ein paar Milimeter.
+nur ein paar Millimeter.
 Der Entstehungsmechanismus ist unabh"angig von der
 Gr"ossenskala immer der Selbe.
 Diese Unabh"angigkeit von der Gr"ossenskala
@@ -32,7 +32,7 @@ In diesem Abschnitt sollen die Eigenschaften solcher Verteilungen abgeleitet
 werden.
 
 \subsubsection{Skalenunabh"angigkeit und Potenzgesetze}
-Wir untersuchen nun Zufallsvariablen $X$ wie zum Beispiel den Durchmesser
+Wir untersuchen nun Zufallsvariablen $X$, wie zum Beispiel den Durchmesser
 von Mondkratern. 
 Die Verteilung soll also f"ur jeden beliebigen
 Mass\-stab gelten.
@@ -405,7 +405,7 @@ Mit der Dichtefunktion
 \[
 \varphi(x)=\frac{\alpha-1}{x_{\min}}\left(\frac{x}{x_{\min}}\right)^{-\alpha}
 \]
-wird die Likelihoodfunktion
+wird die Likelihood-Funktion
 \[
 L(\alpha;x_1,\dots,x_n)=
 \left(\frac{\alpha-1}{x_{\min}}\right)^n

--- a/skript/schaetzen.tex
+++ b/skript/schaetzen.tex
@@ -37,8 +37,8 @@ Sch"atzverfahren f"ur eine Gr"osse wie die Varianz gefunden werden kann.
 Etwas genauer geht es um folgendes Problem.
 Von einer gegebenen Zufallsvariable
 $X$ ist die Verteilung nicht bekannt, es wird angenommen, dass die
-Verteilungsfunktion die Form $F(x,\vartheta)$ hat, wobei die $\vartheta$
-ein Vektor vorl"aufig noch unbekannter Parameter ist.
+Verteilungsfunktion die Form $F(x,\vartheta)$ hat, wobei
+$\vartheta$ ein vorl"aufig noch unbekannter Parameter ist.
 Bei einer Normalverteilung sind dies zum Beispiel der Erwartungswert und
 die Varianz: $\vartheta=(\mu,\sigma^2)$.
 Nun wird das
@@ -109,8 +109,8 @@ Sch"atzer f"ur den Erwartungswert und die Varianz, und untersuchen
 sie daraufhin, ob sie erwartungstreu sind.
 In den Abschnitten \ref{section-maximum-likelihood-schaetzer}
 und \ref{section-weitere-beispiele-von-schaetzern} wird an einigen
-Beispielen gezeigt, wie man Sch"atzer nach dem Maximum Likelihood
-Prinzip konstruieren kann.
+Beispielen gezeigt, wie man Sch"atzer nach dem
+Maximum-Likelihood-Prinzip konstruieren kann.
 In \ref{section-verteilung-der-schaetzwerte}
 wird die Verteilung der Sch"atzer studiert, eine Grundlage, damit
 anschliessend in \ref{section-konfidenzintervalle} Konfidenzintervall
@@ -275,14 +275,14 @@ wenn
 \end{equation}
 \end{definition}
 
-\section{Maximum Likelihood Sch"atzer} \label{section-maximum-likelihood-schaetzer}
+\section{Maximum-Likelihood-Sch"atzer} \label{section-maximum-likelihood-schaetzer}
 \subsection{Stetige Verteilung}
 Ein weiteres Prinzip, welches ``vern"unftige'' Sch"atzer liefert,
-ist das Maximum Likelihood Prinzip.
+ist das Maximum-Likelihood-Prinzip.
 Ist $X$ eine Zufallsvariable, deren
 Verteilung eine Dichtefunktion $f(x,\vartheta)$ mit einem unbekannten
-Parameter $\vartheta$ besitzt, $\vartheta$ soll gesch"atzt werden.
-Wir bilden daraus die Likelihood Funktion
+Parameter $\vartheta$ besitzt. $\vartheta$ soll gesch"atzt werden.
+Wir bilden daraus die Likelihood-Funktion
 \begin{equation}
 L(x_1,\dots,x_n;\vartheta)=f(x_1,\vartheta)\cdots f(x_n,\vartheta),
 \label{likelihood-funktion}
@@ -293,21 +293,22 @@ unabh"angigen, identisch zu $X$ verteilten Zufallsvariablen.
 Die Likelihood-Funktion wird um so gr"osser, je wahrscheinlicher
 es ist, die Werte der Stichprobe in einem $n$-dimensionalen W"urfel
 $dx_1\,dx_2\dots dx_n$ zu finden.
-Das Maximum Likelihood-Prinzip
+Das Maximum-Likelihood-Prinzip
 verlangt nun, dass man als Sch"atzwert f"ur $\vartheta$ jenen Wert
 w"ahlt, der die Likelihood-Funktion maximiert.
 
 \begin{definition}
-$\vartheta(X_1,\dots,X_n)$ heisst Maximum Likelihood Sch"atzer f"ur
-$\vartheta$, wenn die Likelihood Funktion (\ref{likelihood-funktion})
+$\vartheta(X_1,\dots,X_n)$ heisst Maximum-Likelihood-Sch"atzer f"ur
+$\vartheta$, wenn die Likelihood-Funktion (\ref{likelihood-funktion})
 maximal wird:
 \begin{equation}
 L(X_1,\dots,X_n;\vartheta(X_1,\dots,X_n)) \ge L(X_1,\dots,X_n;t)\quad\forall t.
 \end{equation}
 \end{definition}
 
-Um das Prinzip zu illustrieren, berechnen wir den Maximum Likelihood
-Sch"atzer f"ur den Erwartungswert einer normalverteilten Zufallsvariable.
+Um das Prinzip zu illustrieren, berechnen wir den
+Maximum-Likelihood-Sch"atzer f"ur den Erwartungswert
+einer normalverteilten Zufallsvariable.
 Die Dichtefunktion ist 
 \[
 f(x,\vartheta)=\frac1{\sqrt{2\pi}}e^{-\frac{(x-\vartheta)^2}{2\sigma^2}}
@@ -319,7 +320,7 @@ L(x_1,\dots,x_n;\vartheta)=
 \label{likelihood-funktion-normalverteilung}
 \end{equation}
 ergibt.
-Zu gegebenen $X_1,\dots,X_n$ muss nun $\vartheta$ so gefunden
+Zu den gegebenen $X_1,\dots,X_n$ muss nun $\vartheta$ so gefunden
 werden, dass die Likelihood-Funktion
 (\ref{likelihood-funktion-normalverteilung}) maximiert wird.
 Dies geschieht offensichtlich genau dann, wenn die Summe im Exponenten
@@ -328,7 +329,7 @@ ihren kleinsten Wert annimmt, wir m"ussen also ein Minimum von
 \sum_{i=1}^n (x_i-\vartheta)^2
 \end{equation}
 finden.
-Durch Ableiten nach $\vartheta$ ensteht daraus
+Durch Ableiten nach $\vartheta$ entsteht daraus
 \begin{equation}
 \frac{d}{d\vartheta}
 \sum_{i=1}^n (x_i-\vartheta)^2
@@ -343,14 +344,14 @@ Der altbekannte Mittelwert einer Stichprobe ist also auch der
 Maximum Likelihood Sch"atzer f"ur den Erwartungswert einer normalverteilten
 Zufallsvariable.
 \begin{satz}
-Der Stichprobenmittelwert ist der Maximum Likelihood Sch"atzer
+Der Stichprobenmittelwert ist der Maximum-Likelihood-Sch"atzer
 f"ur den Erwartungswert einer normalverteilten Zufallsvariable.
 \end{satz}
 Nach demselben Muster kann man aus die Stichprobenvarianz $S^2$ als
-Maximum Likelihood Sch"atzer konstruieren.
+Maximum-Likelihood-Sch"atzer konstruieren.
 
 \subsection{Diskrete Verteilung}
-Das Maximum Likelihood Prinzip L"asst sich auch bei diskreten Verteilungen
+Das Maximum-Likelihood-Prinzip L"asst sich auch bei diskreten Verteilungen
 anwenden.
 Anstelle der Dichtefunktion treten die Wahrscheinlichkeiten
 $p(x, \vartheta)$, welche nur f"ur eine diskrete Menge von $x$-Werten
@@ -360,7 +361,7 @@ Die Likelihood-Funktion ist dann
 L(x_1,\dots,x_n;\vartheta)=p(x_1,\vartheta)\dots p(x_n,\vartheta),
 \label{likelihood-funktion-diskret}
 \end{equation}
-und die Konstruktion des Maximum Likelihood Sch"atzers l"asst sich genau
+und die Konstruktion des Maximum-Likelihood-Sch"atzers l"asst sich genau
 wie im stetigen Fall durchziehen.
 
 Als Beispiel betrachten wir eine Zufallsvariable $X$ mit Werten $0$ und
@@ -368,7 +369,7 @@ $1$, wobei $1$ mit der Wahrscheinlichkeit $p$ angenommen wird,
 und versuchen, den Parameter $p$ zu sch"atzen.
 Die Wahrscheinlichkeit
 f"ur den Wert $0$ ist $1-p$.
-Daraus l"asst sich die Likelihood Funktion konstruieren
+Daraus l"asst sich die Likelihood-Funktion konstruieren
 \begin{equation}
 L(k_1,\dots,k_n;p)=p^{\sum_{i=1}^nk_i}(1-p)^{n-\sum_{i=1}^nk_i},
 \label{likelihood-funktion-p}
@@ -377,8 +378,8 @@ wobei die $k_i$ nur die Werte $0$ und $1$ annehmen k"onnen.
 Die Summe 
 $K=\sum_{i=1}^nk_i$ ist die Anzahl der F"alle, in denen der Wert $1$
 angenommen wurde.
-Nach dem Maximum Likelihood
-Prinzip ist $p$ so zu bestimmen, dass die Likelihood-Funktion
+Nach dem Maximum-Likelihood-Prinzip ist $p$ so zu bestimmen,
+dass die Likelihood-Funktion
 (\ref{likelihood-funktion-p})
 maximal wird.
 Dabei bleibt $K$ unver"andert, es ist also der Ausdruck
@@ -396,12 +397,12 @@ Nach Division durch $p^{K-1}(1-p)^{n-K-1}$ wird daraus
 K(1-p)-(n-K)p=K-np=0.
 \end{equation}
 Diese Gleichung kann man nach $p$ aufl"osen: $p=K/n$.
-Somit ist die relative H"aufigkeit der Maximum Likelihood Sch"atzer
+Somit ist die relative H"aufigkeit der Maximum-Likelihood-Sch"atzer
 f"ur die Wahrscheinlichkeit $p$.
 \begin{satz}
-Der Stichprobenmittelwert ist der Maximum Likelihood Sch"atzer
+Der Stichprobenmittelwert ist der Maximum-Likelihood-Sch"atzer
 f"ur die Wahrscheinlichkeit $p$ eines
-positiven Ausgangs eines Bernoulli-Experimentes.
+positiven Ausgangs eines Bernoulliexperimentes.
 \end{satz}
 
 \section{Weitere Beispiele von Sch"atzern} \label{section-weitere-beispiele-von-schaetzern}
@@ -458,7 +459,7 @@ gleichverteilten Zufallsvariable $X$, dann ist
 eine erwartungstreuer Sch"atzer f"ur die Intervalll"ange $\vartheta$.
 \end{satz}
 
-\subsection{Sch"atzung des Parameters \texorpdfstring{$\lambda$}{lamda} einer Poissonverteilung}
+\subsection{Sch"atzung des Parameters \texorpdfstring{$\lambda$}{lambda} einer Poissonverteilung}
 Die Zufallsvariable $X$ sei poissonverteilt, d.~h.
 \begin{equation}
 p(k, \lambda)=\frac{\lambda^k}{k^!}e^{-\lambda}.
@@ -466,7 +467,7 @@ p(k, \lambda)=\frac{\lambda^k}{k^!}e^{-\lambda}.
 Der Parameter $\lambda$ soll aus einer Stichprobe gesch"atzt werden.
 Dazu bilden wir die Likelihood Funktion
 \begin{equation}
-L(k_1,\dots k_n;\lambda)=\frac{\lambda^{k_1+\dots+k_n}}{k_1!\cdots k_n!}
+L(k_1,\dots k_n;\lambda)=\frac{\lambda^{k_1+\dots+k_n}}{k_1!\dotsm k_n!}
 \,e^{-n\lambda}.
 \label{poisson-likelihood-funktion}
 \end{equation}
@@ -476,10 +477,10 @@ bestimmt:
 \begin{align}
 \frac{d}{d\lambda}L(k_1,\dots,k_n;\lambda)
 &=
-\frac{1}{k_1!\cdots k_n!}(K\lambda^{K-1}-n\lambda^K)e^{-n\lambda}\nonumber
+\frac{1}{k_1!\dotsm k_n!}(K\lambda^{K-1}-n\lambda^K)e^{-n\lambda}\nonumber
 \\
 &=
-\frac{1}{k_1!\cdots k_n!}(K-n\lambda)\lambda^{K-1}e^{-n\lambda}.
+\frac{1}{k_1!\dotsm k_n!}(K-n\lambda)\lambda^{K-1}e^{-n\lambda}.
 \label{poisson-likelihood-ableitung}
 \end{align}
 Die Ableitung verschwindet genau dann, wenn der Klammerausdruck in
@@ -494,7 +495,7 @@ konsistent und erwartungstreu.
 \subsection{Sch"atzung von \texorpdfstring{$p$}{p} in einer Binomialverteilung}
 Von der Zufallsvariablen $X$ sei bekannt, dass sie binomialverteilt ist
 mit Parameter $(m, p)$, der Parameter $p$ ist zu sch"atzen.
-Die Likelihoodfunktion ist in diesem Fall
+Die Likelihood-Funktion ist in diesem Fall
 \begin{equation}
 L(k_1,\dots,k_n;p)=\biggl(\prod_{i=1}^n\binom{m}{k_i}\biggr)
 p^{K}(1-p)^{nm-K},
@@ -521,7 +522,7 @@ Somit ist
 \begin{equation}
 p(k_1,\dots,k_n)=\frac1{nm}\sum_{i=1}^nk_i
 \end{equation}
-der Maximum Likelihood Sch"atzer f"ur $p$.
+der Maximum-Likelihood-Sch"atzer f"ur $p$.
 Offensichtlich ist er konsistent
 und erwartungstreu.
 \begin{satz}
@@ -534,7 +535,7 @@ $\frac1{m}\bar X$.
 Sch"atzwerte entstehen dadurch, dass die Werte einer Stichprobe, also
 gewisse Realisierungen von Zufallsvariablen in die Sch"atzfunktion
 eingesetzt werden.
-Somit sind die Sch"atzwert selbst wieder Zufallsvariable,
+Somit sind die Sch"atzwerte selbst wieder Zufallsvariablen,
 und es stellt sich die Frage, welcher Verteilung sie gehorchen.
 
 F"ur einen Spezialfall haben wir uns um diese Problem bereits gek"ummert.
@@ -573,7 +574,7 @@ Zun"achst gilt
 \begin{equation}
 M_{X_i}(t_i)=\exp\biggl(\mu t_i+\frac{\sigma^2t_i^2}2\biggr).
 \end{equation}
-Wir betrachten jetzt den Vektor $U=(U_1,\dots,U_n)$ bestehend aus
+Wir betrachten jetzt den Vektor $U=(U_1,\dots,U_n)$, bestehend aus
 den Zufallsvariablen $U_i=X_i-\bar X$, und $V=\bar X$.
 Wir setzen $\bar s=(s_1+\dots +s_n)/n$.
 Die gemeinsame momenterzeugende Funktione
@@ -650,7 +651,7 @@ W=Z^2=\frac{n(\bar X-\mu)^2}{\sigma^2}
 \end{equation}
 $\chi^2_1$-verteilt.
 Wir setzen $Y=(n-1)S^2/\sigma^2$.
-$W$ und $Y$ sind nach dem eben bewiesenen unabh"angig.
+$W$ und $Y$ sind nach dem eben Bewiesenen unabh"angig.
 Wir behaupten
 \[
 T=W+Y.
@@ -670,7 +671,7 @@ W+Y
 \frac{1}{\sigma^2}\sum_{i=1}^n(X_i-\mu)^2
 \label{wy-chi2}
 \end{align}
-Im lezten Schritt (\ref{wy-chi2}) haben wir den Hilfssatz
+Im letzten Schritt (\ref{wy-chi2}) haben wir den Hilfssatz
 \ref{hilfssatz-varianz-mittelwert}
 weiter unten verwendet.
 F"ur die momenterzeugenden Funktionen bedeutet dies
@@ -709,7 +710,7 @@ Insbesondere bilden die Punkte $(\bar x,\dots,\bar x)$, $(\mu,\dots,\mu)$
 und $(x_1,\dots,x_n)$ bilden ein rechtwinkliges Dreieck.
 Dies erlaubt,
 die Entfernung zwischen $(\mu,\dots,\mu)$ und $(x_1,\dots,x_n)$ 
-als Hypothenuse mit Hilfe des Satzes von Pythagoras zu berechnen:
+als Hypotenuse mit Hilfe des Satzes von Pythagoras zu berechnen:
 \[
 \sum_{i=1}^n(x_i-\mu)^2
 =\sum_{i=1}^n(\bar x-\mu)^2+\sum_{i=1}^n(x_i-\bar x)^2,
@@ -806,7 +807,7 @@ Dazu muss die Verteilung der Zufallsvariable
 \label{konfidenzintervall-verteilung}
 \end{equation}
 bekannt sein.
-Im Nenner ist $(n-1)S^2/\sigma^2$ ist eine
+Im Nenner ist $(n-1)S^2/\sigma^2$ eine
 $\chi_{n-1}^2$-verteilte Zufallsvariable,
 der Z"ahler ist standardnormalverteilt.
 Der Quotient ist "uber den
@@ -821,7 +822,7 @@ t=\frac{Z}{\sqrt{V/k}}
 die $t$-Verteilung mit $k$ Freiheitsgraden.
 \end{definition}
 
-\begin{satz}Die Wahrscheinlichkeitdichte der $t$-Verteilung ist
+\begin{satz}Die Wahrscheinlichkeitsdichte der $t$-Verteilung ist
 \begin{equation}
 \varphi_t(t)=\frac{\Gamma(\frac{k+1}{2})}{\sqrt{\pi k}\Gamma(\frac{k}2)}
 \biggl(1+\frac{t^2}{k}\biggr)^{-\frac{k+1}2}
@@ -868,7 +869,7 @@ Die Dichtefunktion f"ur den Quotienten ist dann
 \frac1{\sqrt{k\pi}2^{\frac{k-1}2}\Gamma(\frac{k}2)}
 \int_0^\infty e^{-\frac12(1+t^2/k)y^2} \,dy.
 \end{align*}
-Mit Hilfe der Subsitution $s=\frac12(1+\frac{t^2}n)y^2$
+Mit Hilfe der Substitution $s=\frac12(1+\frac{t^2}n)y^2$
 oder
 \[
 y=\frac{2^{\frac12}s^{\frac12}}{(1+\frac{t^2}n)^{\frac12}}

--- a/skript/skript.tex
+++ b/skript/skript.tex
@@ -27,6 +27,12 @@
 \usepackage{array}
 \makeindex
 \setlength{\headheight}{15pt} % fix for headheight warning
+
+% better modulo spacing http://www.matthewflickinger.com/blog/archives/2005/02/20/latex_mod_spacing.asp
+\makeatletter
+	\def\imod#1{\allowbreak\mkern10mu({\operator@font mod}\,\,#1)}
+\makeatother
+
 \begin{document}
 \pagestyle{fancy}
 \lhead{Wahrscheinlichkeit und Statistik}

--- a/skript/spamfilter.tex
+++ b/skript/spamfilter.tex
@@ -70,7 +70,7 @@ Diese Formel zeigt auch, dass W"orter, die in Spam h"aufig, in normalen
 Mails aber selten sind, die Wahrscheinlichkeit f"ur Spam hochtreiben.
 
 \subsection{Kombinierte Kriterien}
-Ein leistungsf"ahger Spamfilter wird aber nicht nur ein einziges Kriterium
+Ein leistungsf"ahiger Spamfilter wird aber nicht nur ein einziges Kriterium
 untersuchen, sondern er wird versuchen, Kombinationen von Kriterien, die
 auf Spam hinweisen, zu erkennen und entsprechend die Wahrscheinlichkeit
 zu erh"ohen, eine Message als Spam zu erkennen.
@@ -91,7 +91,9 @@ Ausserdem sind auch $P(S)$ und $P(\bar S)$ bekannt.
 F"ur die Berechnung von $P(S|X\cap Y)$ verwendet man jetzt wieder
 den Satz von Bayes:
 \begin{align}
-P(S|X\cap Y)&=&\frac{P(X\cap Y|S)P(S)}{P(X\cap Y)}\nonumber
+P(S|X\cap Y)
+&=
+\frac{P(X\cap Y|S)P(S)}{P(X\cap Y)}\nonumber
 \\
 &=
 \frac{P(X\cap Y|S)P(S)}{P(X\cap Y|S)P(S)+P(X\cap Y|\bar S)P(\bar S)}
@@ -135,7 +137,8 @@ P(S|X\cap Y)
 &=
 \frac{P(X|S)P(Y|S)P(S)}{P(X|S)P(Y|S)P(S)+P(X|\bar S)P(Y|\bar S)P(\bar S)}\nonumber
 \\
-&=\frac{\displaystyle
+&=
+\frac{\displaystyle
 \frac{P(S|X)P(X)}{P(S)}
 \frac{P(S|Y)P(Y)}{P(S)}P(S)
 }{\displaystyle

--- a/skript/stetige-verteilungen.tex
+++ b/skript/stetige-verteilungen.tex
@@ -4,10 +4,9 @@
 % (c) 2006-2015 Prof. Dr. Andreas MŸller
 %
 \rhead{Verteilungen}
-\chapter{Ein Katalog von Wahrscheinlichkeitsverteilungen
-\label{chapter-wahrscheinlichkeitsverteilung-katalog}}
+\chapter{Ein Katalog von Wahrscheinlichkeitsverteilungen} \label{chapter-wahrscheinlichkeitsverteilung-katalog}
 Im Laufe der Zeit ist eine grosse Zahl von Verteilungen gefunden worden,
-die die verschiedensten von Zufalls beeinflussten Prozesse in der realen
+welche die verschiedensten vom Zufall beeinflussten Prozesse in der realen
 Welt beschreiben.
 In diesem Kapitel werden einige praktisch wichtige Verteilungen vorgestellt.
 

--- a/skript/testen.tex
+++ b/skript/testen.tex
@@ -28,7 +28,7 @@ Der Hypothesentest ist daher das moderne Gegenst"uck zu Bacons
 experimentum crucis.
 Er erlaubt dem Experimentator auf neutrale
 Art zu entscheiden, ob in seinen Messresultaten nun der vermutete
-Effekt sichtbar ist, oder die Endeckung auch nur durch die unvermeidlichen
+Effekt sichtbar ist, oder die Entdeckung auch nur durch die unvermeidlichen
 Zufallsschwankungen vorgespiegelt sein k"onnte.
 
 In Kapitel \ref{chapter-schaetzen} wurde gezeigt, wie Parameter einer
@@ -57,8 +57,8 @@ Wahrscheinlichkeit zu Unrecht an der G"ultigkeit der Hypothese gezweifelt
 wurde.
 
 \section{Allgemeines Prinzip}
-Als Illustration des allgmeinen Problems betrachten wir folgende Frage.
-Von einer Zufallsgr"osse $X$ wird behauptet, dass sie normalverteilt ist
+Als Illustration des allgemeinen Problems betrachten wir folgende Frage.
+Von einer Zufallsgr"osse $X$ wird behauptet, dass sie normalverteilt ist,
 mit Erwartungswert $0$ und Varianz $1$.
 Nun wird eine Messung durchgef"uhrt, bei der der Wert $10$ gemessen wird.
 Die Normalverteilung verbietet nat"urlich
@@ -269,8 +269,8 @@ diskrete Wahrscheinlichkeitsverteilung erweitern l"asst.
 Wir nehmen
 dazu an, dass in einem Experiment $d+1$ Ausg"ange m"oglich sind, und
 bezeichnen diese mit $0,\dots,d$.
-Das Experiment wird $n$ mal
-durchgef"uhrt, wobei der Ausgang $i$ $n_i$ mal beobachtet wurde.
+Das Experiment wird $n$ Mal
+durchgef"uhrt, wobei der Ausgang $i$ $n_i$ Mal beobachtet wurde.
 Mit diesen Daten m"ochten wir die Hypothese testen, dass $p_i$ die
 Wahrscheinlichkeit f"ur den Ausgang $i$ ist.
 
@@ -366,12 +366,12 @@ kurz KS-Test.
 Dieser vergleicht direkt die heuristische, d.~h.~aus den Beobachtungen gewonnene
 Verteilungsfunktion mit der erwarteten Verteilungsfunktion.
 Er legt fest,
-wie die Unterschiede zwischen den zwei Funktionen gemesssen werden sollen,
+wie die Unterschiede zwischen den zwei Funktionen gemessen werden sollen,
 und legt fest, wann eine Abweichung zu gross ist.
 
 Wir wollen testen, ob $n$ Beobachtungen $X_1,\dots,X_n$ sich mit
 der Hypothese vertragen, dass die Zufallsvariablen $X_i$ die
-Verteilungsfunktion $F$ habent.
+Verteilungsfunktion $F$ haben.
 Dazu wird aus den $n$ Beobachtungen
 und die zugeh"orige empirische Verteilungsfunktion
 \[
@@ -507,7 +507,7 @@ sind, der Ausdruck
 In (\ref{kpn-erstes-integral}) hatten wir angenommen,
 dass die Bedingungen f"ur $Y_{n-1}$
 bereits erf"ullt sind, also die Wahrscheinlichkeit f"ur deren zutreffen $1$
-ist, inzwischen haben wir gelernt, dass diese Wahrscheinlichkeit in
+ist. Inzwischen haben wir gelernt, dass diese Wahrscheinlichkeit in
 Wahrheit eher wie (\ref{kpn-zweites-integral}) aussieht.
 Zusammen finden wir
 \begin{equation}
@@ -519,7 +519,7 @@ P(\alpha_n\le Y_n\le n\wedge \alpha_{n-1}\le Y_{n-1}\le Y_n)
 In diesem Sinne k"onnen schrittweise die Bedingungen an $Y_{n-2},\dots,Y_1$
 erf"ullt werden, wir erhalten
 \begin{equation}
-\frac{\int_{\alpha_n}^n dy_n\int_{\alpha_{n-1}}^{y_n}dy_{n-1}\dots\int_{\alpha_1}^{y_2}dy_1}{\int_0^ndy_n\int_0^{y_n}dy_{n-1}\dots\int_0^{y_2}dy_1}
+\frac{\int_{\alpha_n}^n dy_n\int_{\alpha_{n-1}}^{y_n}dy_{n-1}\dotsi\int_{\alpha_1}^{y_2}dy_1}{\int_0^ndy_n\int_0^{y_n}dy_{n-1}\dotsi\int_0^{y_2}dy_1}
 \label{kpn-alle-integrale}
 \end{equation}
 Diese Integrale sind nicht ganz selbstverst"andlich auszurechnen, weshalb
@@ -529,7 +529,7 @@ wir dies hier schrittweise durchf"uhren.
 \label{kn-elementarvolumen}
 Es gilt
 \begin{equation}
-\int_0^xdy_n\int_0^{y_n}dy_{n-1}\dots\int_0^{y_2}dy_1=\frac{x^n}{n!}
+\int_0^xdy_n\int_0^{y_n}dy_{n-1}\dotsi\int_0^{y_2}dy_1=\frac{x^n}{n!}
 \end{equation}
 \end{satz}
 \begin{proof}[Beweis] Wir f"uhren den Beweis mit vollst"andiger
@@ -544,7 +544,7 @@ berechnet werden, was offensichtlich mit $\frac{x^1}{1!}=x$
 Nehmen wir an, dass die Formel f"ur $n-1$ stimmt, dann k"onnen wir den
 Fall $n$ wie folgt verifizieren:
 \[
-\int_0^xdy_n\int_0^{y_n}dy_{n-1}\dots\int_0^{y_2}dy_1
+\int_0^xdy_n\int_0^{y_n}dy_{n-1}\dotsi\int_0^{y_2}dy_1
 =
 \int_0^x\frac{y_n^{n-1}}{(n-1)!}\,dy_n
 =
@@ -569,7 +569,7 @@ die Form
 \[
 P_{nk}(x)
 =
-\int_{n-t}^xdx_n\int_{n-1-t}^{x_n}dx_{n-1}\dots\int_{k+1-t}^{x_{k+2}}dx_{k+1}\int_0^{x_{k+1}}dx_k\dots\int_0^{x_2}dx_1
+\int_{n-t}^xdx_n\int_{n-1-t}^{x_n}dx_{n-1}\dotsi\int_{k+1-t}^{x_{k+2}}dx_{k+1}\int_0^{x_{k+1}}dx_k\dotsi\int_0^{x_2}dx_1
 \]
 hat, es ist dies das gr"osste $k$, f"ur welches $k-t\le 0$ ist, also
 $k=\lfloor t\rfloor$.
@@ -588,7 +588,7 @@ fest, der unmittelbar aus dem Satz \ref{kn-elementarvolumen} folgt.
 \label{kn-variablentransformation}
 Es gilt
 \begin{equation}
-P_{nk}(x)=\int_{n}^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_{k+1}^{x_{k+2}}dx_{k+1}\int_t^{x_{k+1}}dx_k\dots\int_t^{x_2}dx_1
+P_{nk}(x)=\int_{n}^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_{k+1}^{x_{k+2}}dx_{k+1}\int_t^{x_{k+1}}dx_k\dotsi\int_t^{x_2}dx_1
 \label{kpn-variablen-transformation}
 \end{equation}
 \end{satz}
@@ -599,16 +599,16 @@ $t$ hinzuaddiert werden:
 \begin{align}
 P_{nk}(x)
 &=
-\int_{n-t}^xdx_n\int_{n-1-t}^{x_n}dx_{n-1}\dots\int_{k+1-t}^{x_{k+2}}dx_{k+1}\int_0^{x_{k+1}}dx_k\dots\int_0^{x_2}dx_1
+\int_{n-t}^xdx_n\int_{n-1-t}^{x_n}dx_{n-1}\dotsi\int_{k+1-t}^{x_{k+2}}dx_{k+1}\int_0^{x_{k+1}}dx_k\dotsi\int_0^{x_2}dx_1
 \nonumber\\
 &=
-\int_{n}^{x+t}d\xi_n\int_{n-1}^{x_n+t}d\xi_{n-1}\dots\int_{k+1}^{x_{k+2}+t}dx_{k+1}\int_t^{x_{k+1}+t}d\xi_k\dots\int_t^{x_2+t}d\xi_1
+\int_{n}^{x+t}d\xi_n\int_{n-1}^{x_n+t}d\xi_{n-1}\dotsi\int_{k+1}^{x_{k+2}+t}dx_{k+1}\int_t^{x_{k+1}+t}d\xi_k\dotsi\int_t^{x_2+t}d\xi_1
 \nonumber\\
 &=
-\int_{n}^{x+t}d\xi_n\int_{n-1}^{\xi_n}d\xi_{n-1}\dots\int_{k+1}^{\xi_{k+2}}dx_{k+1}\int_t^{\xi_{k+1}}d\xi_k\dots\int_t^{\xi_2}d\xi_1
+\int_{n}^{x+t}d\xi_n\int_{n-1}^{\xi_n}d\xi_{n-1}\dotsi\int_{k+1}^{\xi_{k+2}}dx_{k+1}\int_t^{\xi_{k+1}}d\xi_k\dotsi\int_t^{\xi_2}d\xi_1
 \nonumber\\
 &=
-\int_{n}^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_{k+1}^{x_{k+2}}dx_{k+1}\int_t^{x_{k+1}}dx_k\dots\int_t^{x_2}dx_1
+\int_{n}^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_{k+1}^{x_{k+2}}dx_{k+1}\int_t^{x_{k+1}}dx_k\dotsi\int_t^{x_2}dx_1
 \label{kpn-umbenennung}
 \end{align}
 Im letzten Schritt (\ref{kpn-umbenennung}) haben wir die Integrationsvariablen
@@ -635,7 +635,7 @@ berechnen wir $P_{n0}(x)$ wie folgt:
 \begin{align*}
 P_{n0}(x)
 &=
-\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_1^{x_2}dx_1
+\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_1^{x_2}dx_1
 \\
 &=
 \int_n^{x+t}dx_n\,P_{n-1,0}(x_n-t)
@@ -684,15 +684,15 @@ dann gilt
 \begin{align*}
 \Delta_{nk}(x)
 &=
-\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_{k+1}^{x_{k+2}}dx_{k+1}
-\int^{x_{k+1}}_{\color{red}t} dx_k\dots\int_t^{x_2}dx_1
+\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_{k+1}^{x_{k+2}}dx_{k+1}
+\int^{x_{k+1}}_{\color{red}t} dx_k\dotsi\int_t^{x_2}dx_1
 \\
-&\phantom{=}\quad-\int_n^{x+t} dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_{k+1}^{x_{k+2}}dx_{k+1}
-\int^{x_{k+1}}_{\color{red}k} dx_k\dots\int_t^{x_2}dx_1
+&\phantom{=}\quad-\int_n^{x+t} dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_{k+1}^{x_{k+2}}dx_{k+1}
+\int^{x_{k+1}}_{\color{red}k} dx_k\dotsi\int_t^{x_2}dx_1
 \\
 &=
-\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_{k+1}^{x_{k+2}}dx_{k+1}
-\int_{{\color{red}t\mathstrut}}^{\color{red}k}dx_k\dots\int_t^{x_2}dx_1.
+\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_{k+1}^{x_{k+2}}dx_{k+1}
+\int_{{\color{red}t\mathstrut}}^{\color{red}k}dx_k\dotsi\int_t^{x_2}dx_1.
 \end{align*}
 Da das Integral "uber $x_k$ feste Grenzen $t$ und $k$ hat, reduziert es
 sich auf eine Konstante $c_k$, welche wir weiter unten berechnen werden.
@@ -700,10 +700,10 @@ Die verbleibenden Integrale sind
 \begin{align*}
 \Delta_{nk}(x)
 &=
-c_k\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dots\int_{k+1}^{x_{k+2}}dx_{k+1}
+c_k\int_n^{x+t}dx_n\int_{n-1}^{x_n}dx_{n-1}\dotsi\int_{k+1}^{x_{k+2}}dx_{k+1}
 \\
 &=
-c_k\int_{n-k}^{x-k+t}dx_{n-k}\int_{n-k-1}^{x_{n-k}}dx_{n-k-1}\dots\int_1^{x_2}dx_1
+c_k\int_{n-k}^{x-k+t}dx_{n-k}\int_{n-k-1}^{x_{n-k}}dx_{n-k-1}\dotsi\int_1^{x_2}dx_1
 \\
 &=c_kP_{n-k,0}(x-k),
 \end{align*}
@@ -715,7 +715,7 @@ umbenannt.
 Wir m"ussen uns noch um die Konstante $c_k$ k"ummern.
 Aus der Definition folgt mit Hilfe von Satz \ref{kn-elementarvolumen}
 \begin{equation}
-c_k = \int_{t}^{k}dx_k\dots\int_t^{x_2}dx_1=P_{kk}(k-t)=\frac{(k-t)^k}{k!},
+c_k = \int_{t}^{k}dx_k\dotsi\int_t^{x_2}dx_1=P_{kk}(k-t)=\frac{(k-t)^k}{k!},
 \end{equation}
 die Behauptung.
 \end{proof}
@@ -901,7 +901,7 @@ Auf
 dem Niveau $\alpha=0.01$ finden wir $t_{\infty}^{0.005}=2.576$.
 Da alle Eintr"age in der Tabelle bis auf das Paar $(2002,2005)$
 betragsm"assig gr"osser sind, k"onnen wir auf dem Niveau $\alpha=0.01$
-schliessen, dass die Juli-Durschnittstemperatur zwischen
+schliessen, dass die Juli-Durchschnittstemperatur zwischen
 2001 und 2006 verschieden war.
 Nur f"ur die Jahre 2002 und 2005
 k"onnen wir den Unterschied nicht auf dem Niveau 0.01 sicherstellen.

--- a/skript/verteilung.tex
+++ b/skript/verteilung.tex
@@ -16,12 +16,12 @@ Und mit der linearen Regression haben wir ein Werkzeug kennengelernt,
 um Abh"angigkeiten zwischen Gr"ossen zu detektieren, zu quantifizieren
 und deren Qualit"at zu bewerten.
 
-All dies war m"oglich, ohne dass wir allzuviele Details "uber die
+All dies war m"oglich, ohne dass wir allzu viele Details "uber die
 Wahrscheinlichkeiten wissen mussten, wir mussten einzig in der Lage sein,
 den Erwartungswert und die Varianz zu berechnen.
 Gelungen ist uns dies allerdings erst f"ur diskrete Zufallsvariablen,
 die nur endlich viele verschiedene Werte annehmen.
-F"ur Zufallsvariable, die jeden beliebigen Wert in einem Interval annehmen
+F"ur Zufallsvariable, die jeden beliebigen Wert in einem Intervall annehmen
 k"onnen, funktioniert die bisher verwendete Formel
 ``$\text{Wert}\times\text{Wahrscheinlichkeit}$''
 nicht.
@@ -29,7 +29,7 @@ nicht.
 Etwas Mitschuld an diesem Versagen tr"agt die Tatsache, dass das Modell
 $X\colon\Omega\to\mathbb R$ einer Zufallsvariable zwar die gesamte verf"ugbare
 Information "uber einen Zufallsprozess enth"alt, aber f"ur die Berechnung 
-von Erwartungswerten eigentlich sogar zu viel Information.
+von Erwartungswerten es eigentlich sogar zu viel Information sind.
 Ziel dieses Kapitels ist daher, das Modell so zu vereinfachen, dass
 es gerade noch ausreicht, Erwartungswerte zu berechnen.
 Dabei werden wir andere Informationen aufgeben m"ussen,
@@ -91,7 +91,7 @@ heisst Verteilungsfunktion von $P$.
 \end{definition}
 Die folgenden Eigenschaften folgen unmittelbar aus dieser Definition:
 \begin{enumerate}
-\item Der Wertebereich von $F(x)$ ist im Interval $[0,1]$ enthalten.
+\item Der Wertebereich von $F(x)$ ist im Intervall $[0,1]$ enthalten.
 \item Die Funktion $F(x)$ ist monoton wachsend:
 Da $\{ X \le a\} \subset \{X\le b\}$ falls $a\le b$ folgt
 $F(a)=P(X\le a)\le P(X\le b)=F(b)$.
@@ -302,7 +302,7 @@ p\colon S\to\mathbb{R}:x\mapsto p(x)=P(\{x\}).
 \]
 Diese Funktion muss nat"urlich den Eigenschaften einer
 Wahrscheinlichkeitsfunktion Rechnung tragen, was erf"ullt ist, wenn
-$p(x)\ge 0$ f"ur alle Sprunkpunkte und 
+$p(x)\ge 0$ f"ur alle Sprungpunkte und 
 \[
 \sum_{x\in S}p(x)=1.
 \]
@@ -559,7 +559,7 @@ Gleichverteilung auf den Werten $1,\dots,n=10$
 \centering
 \includegraphics{images/verteilungsfunktion-7.pdf}
 \caption{Verteilungsfunktion und Wahrscheinlichkeitsdichte der stetigen
-Gleichverteilung im Interval $[a,b]$
+Gleichverteilung im Intervall $[a,b]$
 \label{stetige-gleichverteilung}}
 \end{figure}
 \index{Gleichverteilung!stetig}
@@ -705,18 +705,18 @@ y&\qquad 0\le x\le y\\
 %y
 \end{align*}
 Die Verteilungsfunktion von $F(X)$ ist also die Verteilungsfunktion einer
-Gleichverteilung auf dem Interval $[0,1]$.
+Gleichverteilung auf dem Intervall $[0,1]$.
 
 \subsubsection{Anwendung: Erzeugung von Zufallszahlen mit Verteilungsfunktion \texorpdfstring{$F$}{F}}
 Typischerweise stellen Bibliotheken Zufallszahlgeneratoren f"ur Zufallszahlen
-im Interval $[0,1]$ zur Verf"ugung.
+im Intervall $[0,1]$ zur Verf"ugung.
 Um Zufallszahlen mit einer beliebigen Verteilungsfunktion $F$ zu erzeugen,
 verwendet man zun"achst einen solchen Zufallszahlgenerator und wendet dann die
 Funktion $F^{-1}$ an, sofern diese existiert.
 Die resultierenden Zufallszahlen haben Verteilungsfunktion $F$.
 
 \begin{beispiel}
-Die Verteilungsfunktion einer Gleichverteilung im Interval $[a,b]$ ist
+Die Verteilungsfunktion einer Gleichverteilung im Intervall $[a,b]$ ist
 \[
 F(x)=\frac{x-a}{b-a}
 \]
@@ -724,8 +724,8 @@ mit der inversen Funktion
 \[
 F^{-1}(y)=a+(b-a)y.
 \]
-Ist $Y$ eine im Interval $[0,1]$ gleichverteilte Zufallsvariable, dann ist
-$F^{-1}(Y)=a+(b-a)Y$ eine im Interval $[a,b]$ gleichverteilte Zufallsvariable.
+Ist $Y$ eine im Intervall $[0,1]$ gleichverteilte Zufallsvariable, dann ist
+$F^{-1}(Y)=a+(b-a)Y$ eine im Intervall $[a,b]$ gleichverteilte Zufallsvariable.
 \end{beispiel}
 
 \subsection{Variablentransformation}
@@ -742,7 +742,7 @@ $f\colon\mathbb{R}\to\mathbb{R}$.
 Dann ist $Y=f\circ X$ ebenfalls eine
 Zufallsvariable.
 Bezeichnen wir die Verteilungsfunktionen von $X$ und $Y$
-mit $F_X$ bzw.~$F_Y$, dann gilt offensichlich
+mit $F_X$ bzw.~$F_Y$, dann gilt offensichtlich
 \[
 F_Y(y)=P(f\circ X\le y)=P(X\le f^{-1}(y))=F_X(f^{-1}(y))
 \]
@@ -789,7 +789,7 @@ Fall bestimmen l"asst:
 Ist $X$ eine Zufallsvariable, dann heisst die Zahl $\operatorname{med}(X)$,
 f"ur die
 $F(\operatorname{med}(X))=\frac12$ ist, der Median von $X$. 
-Falls mehrer Zahlen diese Bedingung erf"ullen, ist der Median als
+Falls mehrere Zahlen diese Bedingung erf"ullen, ist der Median als
 deren Infimum definiert:
 \[
 \operatorname{med}(X)=\inf \{x\in\mathbb{R}\;|\;F(x)\ge{\textstyle \frac12}\}
@@ -797,7 +797,7 @@ deren Infimum definiert:
 \end{definition}
 F"ur den Median gilt $\operatorname{med}(Y)=f(\operatorname{med}(X))$.
 
-\subsection{Standardisierung\label{section-standardisierung}}
+\subsection{Standardisierung} \label{section-standardisierung}
 \index{Standardisierung}
 Ein wichtiger Spezialfall ist der folgende:
 aus einer Zufallsvariable $X$ mit Erwartungswert
@@ -857,7 +857,7 @@ Da die Werte voneinander unabh"angig sind, ist
 die passende Ereignisalgebra die Produktalgebra, also
 $(x_1,x_2)\in
 \mathbb{R}\times\mathbb{R}$,
-und die Ereignisse sind kartesiches Produkte von Intervallen.
+und die Ereignisse sind kartesische Produkte von Intervallen.
 Dann sind
 die Wahrscheinlichkeiten $P(X_1\le x_1)$  und $P(X_2\le x_2)$ unabh"angig
 voneinander, insbesondere ist $P(X_1\le x_1)=F_1(x_1)$ und
@@ -874,7 +874,7 @@ P(a_1<X_1\le b_1\wedge a_2<X_2\le b_2)
 \int_{a_2}^{b_2}dx_2\,
 \varphi_1(x_1) \varphi_2(x_2).
 \end{align*}
-Die zweidmensionale
+Die zweidimensionale
 Verteilungsfunktion $F(x_1,x_2)=P(X_1\le x_1\wedge X_2\le x_2)$ hat
 also eine zweidimensionale Wahrscheinlichkeitsdichte
 \[
@@ -940,7 +940,7 @@ F(z)&=\int_{-\infty}^{\infty}\int_{-\infty}^{z-x_1}\varphi_1(x_1)\varphi_2(x_2)
 F_2(z-x_1)
 \,dx_1\\
 \end{align*}
-Nun interesssiert uns vor allem die Wahrscheinlichkeitsdichte, also die
+Nun interessiert uns vor allem die Wahrscheinlichkeitsdichte, also die
 ``Ableitung'' von $F$:
 \[
 \varphi(z)=\int_{-\infty}^{\infty}\varphi_1(x_1)\varphi_2(z-x_1)\,dx_1

--- a/skript/wahrscheinlichkeit.tex
+++ b/skript/wahrscheinlichkeit.tex
@@ -296,7 +296,7 @@ gleichzeitig eintreten.
 Der Versuchsausgang $\omega$ ist also so beschaffen, dass mit ihm sowohl
 $A$ als auch $B$ eintreten, dass also $\omega\in A$ und $\omega\in B$,
 oder $\omega \in A\cap B$.
-Gleichzeitigs Eintreten von Ereignis $A$ {\em und} $B$ ist das Ereignis
+Gleichzeitiges Eintreten von Ereignis $A$ {\em und} $B$ ist das Ereignis
 $A\cap B$.
 
 Tritt ein Ereignis $A$ bei einer Versuchsdurchf"uhrung nicht ein, dann trat
@@ -322,7 +322,7 @@ $\emptyset$ heisst daher auch das unm"ogliche Ereignis.
 
 Diese Beispiele zeigen, dass die Modellierung von Ereignissen als Teilmengen
 von $\Omega$
-mit der umgangsprachlichen Sprechweise von Ereignissen "ubereinstimmt.
+mit der umgangssprachlichen Sprechweise von Ereignissen "ubereinstimmt.
 Die Tabelle~\ref{begriffe-zusammenfassung}
 fasst die gebr"auchlichsten Mengenoperationen und die zugeh"orige
 Sprechweise f"ur Ereignisse zusammen.
@@ -360,10 +360,9 @@ Es k"onnen also verschiedene Ereignisse eintreten.
 Meistens wird ein
 positiver AIDS-Test richtig anzeigen, dass eine Person HIV hat.
 Manchmal
-wird der Test jedoch positiv sein, obwohl die Person gesund ist.
-Und manchmal
-wird der Test zwar ein positives Resultat zeigen, aber die Person ist
-an HIV erkrankt.
+wird der Test jedoch positiv sein, obwohl die Person gesund ist
+und manchmal wird der Test zwar ein negatives Resultat zeigen,
+aber die Person ist an HIV erkrankt.
 Gl"uck haben diejenigen, bei denen der Test nicht
 anspricht, und die auch tats"achlich gesund sind.
 
@@ -372,7 +371,7 @@ anspricht, und die auch tats"achlich gesund sind.
 \index{Euromillions}
 \begin{figure}
 \includegraphics[width=\hsize]{graphics/euromillions}
-\caption{Besondere Gewinnchance in Euromillions}
+\caption{Besondere Gewinnchance bei Euromillions}
 \end{figure}
 \begin{figure}
 \begin{center}
@@ -381,7 +380,7 @@ anspricht, und die auch tats"achlich gesund sind.
 \caption{Teilnahmeschein f"ur Euromillions\label{euromillionsschein}}
 \end{figure}
 Am 5.~September 2008 schrieb die Gratiszeitung ``20 Minuten'', dass die
-bevorstehende Ziehung der Lotterie Euromillions besondere Gewinnschancen 
+bevorstehende Ziehung der Lotterie Euromillions besondere Gewinnchancen 
 erm"ogliche, weil der Jackpot ungew"ohnlich gross sei.
 Welche Ereignisse
 sind in diesem Spiel relevant?
@@ -430,7 +429,7 @@ oder aus denen sich der Gewinn noch nicht ableiten l"asst:
 \begin{itemize}
 \item {\it Heiris Euromillions Teilnahmeschein f"allt in Gewinnrang 10.}
 Offenbar teilt sich Heiri 4.7\% der Gewinnsumme mit den anderen Teilnehmern,
-die dasselbe Ergebnis erziehlt haben.
+die dasselbe Ergebnis erzielt haben.
 \item {\it Hanna hatte f"unf richtige Zahlen.}
 Diese Information reicht noch nicht, um den Gewinn festzulegen.
 Hannas Teilnahmeschein f"allt in Gewinnrang 1 oder 2 oder 3.
@@ -492,9 +491,9 @@ In $\Omega$ lassen sich bereits bedeutend spannendere Ereignisse
 beschreiben:
 \begin{align*}
 A_1&=\{\text{mindestens eine ungerade Zahl}\}\\
-   &=\{(x,y)\in\Omega\;|\;x \equiv 1\mod 2 \vee y\equiv 1\mod 2\}\\
+   &=\{(x,y)\in\Omega\;|\;x \equiv 1 \imod{2} \vee y\equiv 1 \imod{2}\}\\
 A_2&=\{\text{beide Augenzahlen sind gerade}\}\\
-   &=\{(x,y)\in\Omega\;|\;2|x \wedge 2|y\}\\
+   &=\{(x,y)\in\Omega\;|\;x \equiv 0 \imod{2} \wedge y \equiv 0 \imod{2}\}\\
 X_i&=\{(i,y)\in\Omega\}\\
 Y_i&=\{(x,i)\in\Omega\}\\
 S_s&=\{(x,y)\in\Omega\;|\; x + y = s\}\\
@@ -514,7 +513,7 @@ X_5\cap D_1&=\{(5,4), (5,6)\}\\
 \centering
 \includegraphics{images/zweiwuerfel-1.pdf}
 \caption{Verschiedene Ereignisse in der Ereignisalgebra des Experiments
-``Wurf zweier verschiedenfarbiger W"urfel\label{zweiwuerfel}}
+``Wurf zweier verschiedenfarbiger W"urfel\label{zweiwuerfel}''}
 \end{figure}
 
 \subsection{Formale Definition}
@@ -550,7 +549,7 @@ Vorlesung keine praktischen Konsequenzen, alle interessierenden
 Ereignisse sind von vornherein in $\cal A$, und damit auch alle daraus
 abgeleiteten Ereignisse.
 
-Wir nennen eine solche Menge von Ereignissen eine Ereignis-Algebra:
+Wir nennen eine solche Menge von Ereignissen eine Ereignisalgebra:
 
 \begin{definition}
 \label{def-ereignisalgebra}
@@ -573,9 +572,9 @@ A,B\in {\cal A}\Rightarrow A\setminus B\in{\cal A}
 
 Sind nur die Bedingungen 1 und 2 erf"ullt, spricht man auch von einem
 Mengen-Ring.
-Eine Ereignisalgebra heisst manchmal auch ein Mengen-K"orper.
+Eine Ereignisalgebra heisst manchmal auch ein Mengenk"orper.
 
-Aus den Axiomen f"ur die Ereignisalgebra lassen sich sofort erst
+Aus den Axiomen f"ur die Ereignisalgebra lassen sich sofort erste
 Schlussfolgerungen ziehen:
 \begin{enumerate}
 \item Es gibt auch das unm"ogliche Ereignis: $\emptyset = \Omega\setminus\Omega\in{\cal A}$.
@@ -661,8 +660,8 @@ P&=\{\text{Pasch im ersten Wurf}\}\\
 \\
 Q&=\{\text{totale Augensumme $\ge 10$}\}\\
 &=\{\phantom{(6,6),} (6,5), (6,4), \\
-&\phantom{\;=\{}(5,6), \phantom{(5,5),} \\
-&\phantom{\;=\{}(4,6)
+&\phantom{\;=\{}(5,6), \phantom{(5,5), (5,4)} \\
+&\phantom{\;=\{}(4,6)\phantom{, (4,5), (4,4)}
 \}
 \\
 &\qquad\cup
@@ -732,7 +731,7 @@ $T\setminus H\ne\emptyset$.
 \end{table}
 Bei einer Messung wird ein Messwert ermittelt, dieser kann jedoch
 nur mit einer begrenzten Genauigkeit festgehalten werden.
-Die Elementarereignisse sind zwar immer noch alle m"oglichen rellen
+Die Elementarereignisse sind zwar immer noch alle m"oglichen reellen
 Zahlen $\mathbb R$, aber sinnvolle Ereignisse sind nur bestimmte Teilmengen
 $A\subset\mathbb R$.
 Wir wollen bestimmen, welche Teilmengen das sind.
@@ -829,7 +828,7 @@ Das wenigstens verbinden wir mit einem unwahrscheinlichen Ereignis.
 Trotzdem kann das Ereignis eintreten.
 
 \subsection{Verschiedene Wahrscheinlichkeitsbegriffe}
-Die Wahrscheinlichkeit soll ein Mass daf"ur sein, dass Ereignis
+Die Wahrscheinlichkeit soll ein Mass daf"ur sein, dass ein Ereignis
 eintritt.
 Es gibt verschiedene Ans"atze, wie wir zu einem solchen Mass kommen
 k"onnten:
@@ -853,7 +852,7 @@ die Wahrscheinlichkeit zu verhalten hat, und dann zu untersuchen,
 ob ein solches Objekt tats"achlich existiert.
 \end{itemize}
 In allen F"allen ergibt sich eine Reihe von Gesetzm"assigkeiten
-oder Formeln, die die jeweiligen Wahrscheinlichkeitsbegriffe 
+oder Formeln, welche die jeweiligen Wahrscheinlichkeitsbegriffe 
 erf"ullen m"ussen.
 Soll die Wahrscheinlichkeit eine objektive Gr"osse sein, dann
 muss f"ur wiederholbare Experimente die f"ur den Bayesschen
@@ -905,18 +904,18 @@ zum Beispiel hindern moralische Bedenken daran, eine grosse
 Zahl von Experimenten mit Menschen durchzuf"uhren.
 Bei der
 Ausbruchswahrscheinlichkeit eines Vulkans oder der
-Einschlagswahrscheinlichkeit eines Asteroiden auf der Erde hat man
+Einschlagwahrscheinlichkeit eines Asteroiden auf der Erde hat man
 ganz einfach keine Kontrolle "uber das Experiment.
 
 Das Ziel der Wahrscheinlichkeitstheorie ist daher, 
 die Abbildung $P\colon {\cal A}\to\mathbb{R}$
-abstrakt zu definieren, und geeignete Axiome zu postulieren, die
+abstrakt zu definieren und geeignete Axiome zu postulieren, die
 der eben skizzierten intuitiven Vorstellung der Wahrscheinlichkeit
 einen strengen Sinn geben.
 Damit wird die Funktion $P$ in vielen
 F"allen berechenbar, meist nat"urlich unter zus"atzlichen Annahmen.
 Die grundlegenden Eigenschaften sind in den folgenden, f"ur
-relative H"aufigkeiten unmittelbar einleuchtenden Axiomen
+relative H"aufigkeiten, unmittelbar einleuchtenden Axiomen
 % XXX
 von Kolmogorov\footnote{Andrei Nikolaiewitsch Kolmogorov, 1903-1987}
 festgehalten.
@@ -1199,7 +1198,7 @@ nach aussen gew"olbte Fl"ache.
 \index{Wurfel@{W\"urfel, fairer}}
 W"urfel haben sechs Seiten, die gem"ass der Annahme eines Laplace-Experiments
 mit gleicher
-Wahrscheinlichkeit obenliegen werden, die Wahrscheinlichkeit jedes
+Wahrscheinlichkeit oben liegen werden, die Wahrscheinlichkeit jedes
 Resultates ist also gleich $P(i) = \frac16, i\in\{1,2,3,4,5,6\}$.
 Wird eine Seite des W"urfels beschwert, f"allt er bevorzugt auf diese
 Seite, und die Wahrscheinlichkeiten sind nicht mehr gleich.
@@ -1291,7 +1290,7 @@ formulieren:
 \omega=(d_1, d_2, d_3,\dots,d_n)
 \]
 Dabei ist $d_1$ das Geburtsdatum der ersten Person, $d_2$ das
-Geburstdatum der zweiten Person, etc.
+Geburtsdatum der zweiten Person, etc.
 Der Einfachheit halber kann
 man f"ur die $d_i$ einfach Zahlen zwischen 1 und 366 nehmen.
 
@@ -1317,7 +1316,7 @@ Man kann ablesen, dass $|\Omega|=366^n$ ist.
 Gefragt ist nun das Ereignis
 ``zwei Personen haben am gleichen Tag Geburtstag''.
 Selbstverst"andlich d"urfen dabei auch alle am gleichen Tag
-Geburstag haben, oder es darf zwei Paare geben, die jeweils
+Geburtstag haben, oder es darf zwei Paare geben, die jeweils
 "ubereinstimmende Geburtstage haben.
 Es darf einfach nicht
 sein, dass alle Geburtstage verschieden sind.
@@ -1341,7 +1340,7 @@ kann man $366$ Geburtstage ausw"ahlen, f"ur die zweite $365$, die
 dritte $364$ etc.
 Insgesamt hat man
 \[
-366\cdot365\cdot364\dots(366-n+1)
+366\cdot365\cdot364\dotsm(366-n+1)
 \]
 M"oglichkeiten.
 Also ist die Wahrscheinlichkeit, dass unter $n$
@@ -1349,12 +1348,12 @@ Personen zwei am gleichen Tag Geburtstag haben:
 \[
 P(A)
 =
-1-\frac{366\cdot365\cdot364\dots(366-n+1)}{366^n}
+1-\frac{366\cdot365\cdot364\dotsm(366-n+1)}{366^n}
 =
 1-\frac{366}{366}\cdot
 \frac{365}{366}\cdot
 \frac{364}{366}
-\cdots
+\dotsm
 \frac{366-n+1}{366}
 .
 \]
@@ -1509,11 +1508,11 @@ $A$ wird unwahrscheinlicher, wenn bereits $B$ eingetreten
 ist.
 \label{abhaengig}}
 \end{figure}
-Der Grund daf"ur, dass es keine einfache Rechenregel f"ur die Berechung von 
+Der Grund daf"ur, dass es keine einfache Rechenregel f"ur die Berechnung von 
 $P(A\cap B)$ aus $P(A)$ und $P(B)$ gibt, wird mit der
 Visualisierung der Ereignisse im in einem Venn-Diagramm sofort klar.
 Die Elementarereignisse seien so angeordnet, dass $A$ das durch eine
-vertikale Strecke abgetrennte linke Teilrechteck von $\Omega$ ist.
+vertikale Strecke abgetrennte, linke Teilrechteck von $\Omega$ ist.
 Ausserdem
 sollen Sie so angeordnet sein, dass die Wahrscheinlichkeit dem
 Fl"acheninhalt im Diagramm entspricht.
@@ -1529,7 +1528,7 @@ berechnen k"onnen.
 
 Wenn sich $B$ ebenfalls mittels einer horizontalen Strecke als Rechteck
 einzeichnen l"asst, dann ist $P(B)$ auch das Teilverh"altnis, in dem
-die Strecke die vertikale Kante des Diagrams teilt.
+die Strecke die vertikale Kante des Diagramms teilt.
 Somit kann man $P(A\cap B)$
 als Fl"acheninhalt des Schnittrechtecks berechnen: $P(A\cap B)=P(A)\cdot P(B)$.
 Die Voraussetzung bedeutet, dass das Eintreffen von $B$ nicht wahrscheinlicher
@@ -1613,8 +1612,8 @@ man
 \[
 P(L|\bar R)=0.01.
 \]
-Der Artikel liefert aber keine Auskunft dar"uber, wieviele der
-lungenkrebskranken Raucher sind, denn das w"are die Wahrscheinlichkeit
+Der Artikel liefert aber keine Auskunft dar"uber, wie viele der
+Lungenkrebskranken auch Raucher sind, denn das w"are die Wahrscheinlichkeit
 $P(R|L)$.
 
 \subsubsection{Zusammenhang zwischen \texorpdfstring{$P(A\cap B)$}{P(A geschnitten B)}, \texorpdfstring{$P(A|B)$}{P(A bedingt B)} und \texorpdfstring{$P(B|A)$}{P(B bedingt A)}}
@@ -1659,7 +1658,7 @@ Wenn wir nun auch
 noch die Wahrscheinlichkeit jedes Zustandes kennen, m"usste es doch
 m"oglich sein, auch die Wahrscheinlichkeit der weiteren Resultate zu
 ermitteln.
-
+% TODO Missing Example
 Im obigen Beispiel der Meinungsumfrage ist anschaulich klar, dass man die
 Wahrscheinlichkeit f"ur ``Ja'' berechnen kann, wenn man einerseits die
 Wahrscheinlichkeit f"ur ``Ja'' in  jeder Altersklasse kennt, und andererseits
@@ -1721,7 +1720,7 @@ da er die Wahrscheinlichkeit eines Ereignisses aus den bedingten
 Wahrscheinlichkeiten unter verschiedenen Voraussetzungen und der
 Wahrscheinlichkeit des Eintretens dieser Voraussetzungen rekonstruiert.
 Dieser Satz ist die ``wahrscheinlichkeitstheoretisch Form einer
-Fallunterscheidung'': man kennnt die F"alle $B_i$, und deren Wahrscheinlichkeit
+Fallunterscheidung'': man kennt die F"alle $B_i$, und deren Wahrscheinlichkeit
 $P(B_i)$, sowie die Wahrscheinlichkeit $P(A|B_i)$, dass $A$ im Falle 
 $B_i$ eintritt.
 Die Formel "uber die totale Wahrscheinlichkeit
@@ -1737,8 +1736,8 @@ Experimentator bedeutet das, dass er nur jene Vorbedingungen $B_i$
 ber"ucksichtigen muss, unter denen sein Experiment ``funktioniert'',
 alle anderen m"oglichen Zust"ande haben keinen Einfluss auf
 die Wahrscheinlichkeit seiner Resultate.
-Man darf beim Experimentieren
-also durchaus einzelne Resultate verwerfen, wenn man weiss, was man tut!
+Man darf beim Experimentieren also durchaus einzelne Resultate
+verwerfen, wenn man weiss, was man tut!
 
 \subsubsection{Studienerfolg}
 Die folgenden Zahlen sind erfunden, und dienen nur der Illustration
@@ -1755,7 +1754,7 @@ Wie gross ist die Wahrscheinlichkeit f"ur den Studienerfolg?
 
 $\Omega$ ist die Menge aller Studienversuche.
 60\% davon bilden das
-Ereigns $B$ bestehend aus Studienversuchen, die im Anschluss an die BMS
+Ereignis $B$ bestehend aus Studienversuchen, die im Anschluss an die BMS
 erfolgen.
 30\% machen das Ereignis $K$ mit den Kanti-Abg"angern aus,
 10\% das Ereignis $A$ mit "Ubertritten von anderen Hochschulen.
@@ -1784,8 +1783,9 @@ Wir m"ochten die Wahrscheinlichkeit berechnen, dass die totale Augensumme
 mindestens 10 ist.
 Wir nennen dieses Ereignis $Z$.
 
-Zun"achst kann man unterteilen in den Fall, dass im ersten Wurf
-ein Pasch geworfen wird.
+Zun"achst kann man unterteilen f"ur den Fall, dass im ersten Wurf
+ein Pasch (Ereignis $P$) geworfen wird.
+
 Es gilt nach dem Satz "uber die totale Wahrscheinlichkeit
 \[
 P(Z) = P(Z|P) P(P) + P(Z|\bar P) P(\bar P).
@@ -1828,9 +1828,9 @@ denn in allen diesen F"allen erreicht man mit dem zweiten Wurf mit
 Sicherheit zehn oder mehr.
 
 \subsection{Ziegen und Autos} \label{ziegen:autos}
-Marylin vos Savant hat in einer Kolumne ein Gedankenexperiment vorgstellt.
+Marylin vos Savant hat in einer Kolumne ein Gedankenexperiment vorgestellt.
 In einer Quiz-Show muss der Kandidat eine von drei T"uren w"ahlen, wobei
-sich hinter einer der T"uren ein Auto versteckt, hinter den anderen zweien
+sich hinter einer der T"uren ein Auto versteckt, hinter den anderen Zweien
 ein Ziege.
 Das Ziel des Spiels ist, das Auto zu gewinnen.
 Nach der Wahl


### PR DESCRIPTION
- Typos fixed
- Changed \mod to \modi -> mod 5 => (mod 5)
- Changed \dots to \dotsi (for integrals) and \dotsm (for multiplications)
- Added comment to wahrscheinlichkeit.tex where an example is mentioned but cannot be found. (Subsection: Zerlegung eines Wahrscheinlichkeitsraumes), see % TODO: Missing Example