### PR TITLE
Add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+with (import <nixpkgs> {});
+mkShell {
+  buildInputs = [
+    gnumake 
+    texlive.combined.scheme-full 
+  ];
+}


### PR DESCRIPTION
Add `shell.nix` so that pdf can easily be built with [NixOS](https://nixos.org/).

To build pdf:
```bash
nix-shell shell.nix
make all  
```